### PR TITLE
Added finalizer permissions

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -37,7 +37,7 @@ rules:
     - create
     - update
     - delete
-#Allow Event recording access
+# Allow Event recording access
  - apiGroups:
     - ""
    resources:
@@ -46,7 +46,7 @@ rules:
     - create
     - update
     - patch
-#Allow Access to CRD
+# Allow Access to CRD
  - apiGroups:
    - apiextensions.k8s.io
    resources:
@@ -57,11 +57,12 @@ rules:
    - watch
    - create
    - update
-#Allow Access to flink applications under flink.k8s.io
+# Allow Access to flink applications under flink.k8s.io
  - apiGroups:
    - flink.k8s.io
    resources:
    - flinkapplications
+   - flinkapplications/finalizers
    verbs:
    - get
    - list

--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -30,8 +30,23 @@ data:
       level: 4
 ```
 
+Then create the ConfigMap containing the configurations:
 ```bash
 $ kubectl create -f deploy/config.yaml
+```
+
+Also edit the resource requirements for the operator deployment if needed. The default are:
+```yaml
+  requests:
+    memory: "4Gi"
+    cpu: "4"
+  limits:
+    memory: "8G"
+    cpu: "8"
+```
+
+Then create the operator Deployment:
+```
 $ kubectl create -f deploy/flinkk8soperator.yaml
 ```
 


### PR DESCRIPTION
1. I tried out the project and found out an issue with starting a Flink app:
```
time="2019-06-03T18:10:48Z" level=error msg="Jobmanager deployment creation failed deployments.apps \"wordcount-operator-example-f5b2ddb2-jm\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: no RBAC policy matched, <nil>" app_name=wordcount-operator-example ns=flink-operator phase=
```
The reason is that the finalizer permissions were not properly given to the ClusterRole. This PR fixed it. (Note: I'm on OpenShift. Not sure if it's OpenShift-specific but this change shouldn't break non-OpenShift k8s).

2. Added some notes about resource requirements when deploying the operator. I wasn't able to deploy initially because of lack of resources. I think it's better to let the user know that the default requirements might not be what he wants.