### PR TITLE
Fix the travis condition to make docker hub push on merge to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
       before_script: integ/setup.sh
       script: "sudo -E \"PATH=$PATH\" integ/test.sh"
     - stage: release
-      if: TRAVIS_PULL_REQUEST = false
+      if: (branch = master AND type = push) OR tag IS present
       name: docker build and push
       install: true
       script: make dockerhub_push


### PR DESCRIPTION
Just noticed, the PRs merged to master are not pushing docker images.

https://travis-ci.org/lyft/flinkk8soperator/builds/540614153?utm_source=github_status&utm_medium=notification

In some cases, the branch is set to master even though it is a PR: https://travis-ci.org/lyft/flinkk8soperator/builds/540887580 so explicitly adding push check

Discussion from here: https://github.com/travis-ci/travis-ci/issues/8767