### PR TITLE
[STRMCMP-507] Add additional printer columns

### DIFF
--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -12,3 +12,32 @@ spec:
 
   scope: Namespaced
   version: v1alpha1
+
+  additionalPrinterColumns:
+    - name: Phase
+      type: string
+      description: The current state machine phase for this FlinkApplication
+      JSONPath: .status.phase
+    - name: Cluster Health
+      type: string
+      description: The health of the Flink cluster
+      JSONPath: .status.clusterStatus.health
+    - name: Job Health
+      type: string
+      description: The health of the Flink job
+      JSONPath: .status.jobStatus.health
+    - name: Healthy TMs
+      type: string
+      JSONPath: ".status.clusterStatus.healthyTaskManagers"
+      priority: 1
+    - name: Total TMs
+      type: string
+      JSONPath: ".status.clusterStatus.numberOfTaskManagers"
+      priority: 1
+    - name: Job Restarts
+      type: integer
+      description: Number of times the job has restarted
+      JSONPath: .status.jobStatus.jobRestartCount
+    - name: Age
+      type: date
+      JSONPath: .metadata.creationTimestamp


### PR DESCRIPTION
This PR adds additional printer columns to the CRD to make it easier to quickly see the status of flink applications.

Example output:

```
$ kubectl get flinkapplications
NAME                PHASE     CLUSTER HEALTH   JOB HEALTH   JOB RESTARTS   AGE
operator-test-app   Running   Green            Green        2             35m

$ kubectl get flinkapplications -owide
NAME                PHASE     CLUSTER HEALTH   JOB HEALTH   HEALTHY TMS   TOTAL TMS   JOB RESTARTS   AGE
operator-test-app   Running   Green            Green        1             1           2             36m
```