### PR TITLE
Minor fixes and improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
   directories:
     - $GOPATH/pkg/dep
 go:
-  - "1.10"
+  - "1.12"
 services:
   - docker
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# Using go1.10.4
-FROM golang:1.10.4-alpine3.8 as builder
+FROM golang:1.12.5-alpine3.9 as builder
 RUN apk add git openssh-client make curl bash
 
 COPY boilerplate/lyft/golang_test_targets/dep_install.sh /go/src/github.com/lyft/flinkk8soperator/
@@ -24,6 +23,6 @@ RUN make linux_compile
 ENV PATH="/artifacts:${PATH}"
 
 # This will eventually move to centurylink/ca-certs:latest for minimum possible image size
-FROM alpine:3.8
+FROM alpine:3.9
 COPY --from=builder /artifacts /bin
 CMD ["flinkoperator"]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The Operator creates flink clusters dynamically using the specified custom resou
 
 Deploying and managing Flink applications in Kubernetes involves two steps:
 
-* **Building Flink application packaged as a docker image:** A docker image is built containing the application source code with the necessary dependencies built in. This is required to bootstrap the Jobmanager and Taskmanager pods. At Lyft we use Source-To-Image [S2I](https://docs.openshift.com/enterprise/3.0/using_images/s2i_images/index.html) as the image build tool that provides a common builder image with Apache Flink pre-installed. The docker image could be built using any pre-existing workflows at an organization.
+* **Building Flink application packaged as a docker image:** A docker image is built containing the application source code with the necessary dependencies built in. This is required to bootstrap the Jobmanager and Taskmanager pods. At Lyft we use Source-To-Image [S2I](https://docs.openshift.com/container-platform/3.11/architecture/core_concepts/builds_and_image_streams.html#source-build) as the image build tool that provides a common builder image with Apache Flink pre-installed. The docker image could be built using any pre-existing workflows at an organization.
 
 * **Creating the Flink application custom resource:** The custom resource for Flink application provides the spec for configuring and managing flink clusters in Kubernetes. The FlinkK8sOperator, deployed on Kubernetes, continuously monitors the resource and the corresponding flink cluster, and performs action based on the diff.
 

--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -74,7 +74,7 @@ $ kubectl get deployments -n flink-operator
 
 Check the phase and other status attributes in the custom resource
 ```bash
-$ kubectl get flinkapplication.flink.k8s.io -n flink-operator wordcount-operator-example -o yaml
+$ kubectl get flinkapplication.flink.k8s.io -n default wordcount-operator-example -o yaml
 ```
 
 The output should be something like this
@@ -135,7 +135,7 @@ status:
 To check events for the `FlinkApplication` object, run the following command:
 
 ```bash
-$ kubectl describe flinkapplication.flink.k8s.io -n flink-operator wordcount-operator-example
+$ kubectl describe flinkapplication.flink.k8s.io -n default wordcount-operator-example
 ```
 
 This will show the events similarly to the following:

--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -62,7 +62,7 @@ $ kubectl logs {pod-name} -n flink-operator
 You can find sample application to run with the flink operator [here](/examples/). To run a flink application, run the following command:
 
 ```bash
-$ kubectl create -f examples/wordcount/flink-operator-custom-resource.yaml -n flink-operator
+$ kubectl create -f examples/wordcount/flink-operator-custom-resource.yaml
 ```
 
 The above command will create the flink application custom resource in kubernetes. The operator will observe the custom resource, and will create a flink cluster in kubernetes.

--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -74,7 +74,7 @@ $ kubectl get deployments -n flink-operator
 
 Check the phase and other status attributes in the custom resource
 ```bash
-$ kubectl get flinkapplication.flink.k8s.io -n default wordcount-operator-example -o yaml
+$ kubectl get flinkapplication.flink.k8s.io -n flink-operator wordcount-operator-example -o yaml
 ```
 
 The output should be something like this
@@ -135,7 +135,7 @@ status:
 To check events for the `FlinkApplication` object, run the following command:
 
 ```bash
-$ kubectl describe flinkapplication.flink.k8s.io -n default wordcount-operator-example
+$ kubectl describe flinkapplication.flink.k8s.io -n flink-operator wordcount-operator-example
 ```
 
 This will show the events similarly to the following:

--- a/examples/wordcount/flink-conf.yaml
+++ b/examples/wordcount/flink-conf.yaml
@@ -1,12 +1,12 @@
 jobmanager.web.submit.enable: true
 jobmanager.web.log.path: /var/log/jobmanager/current
 
-jobmanager.web.upload.dir: /opt/flink
-
 taskmanager.log.path: /var/log/taskmanager/current
 taskmanager.exit-on-fatal-akka-error: true
 taskmanager.network.memory.max: 2147483648
 taskmanager.network.memory.fraction: 0.125
+
+web.upload.dir: /opt/flink
 
 # Akka config
 akka.framesize: 20MB

--- a/examples/wordcount/flink-operator-custom-resource.yaml
+++ b/examples/wordcount/flink-operator-custom-resource.yaml
@@ -2,7 +2,7 @@ apiVersion: flink.k8s.io/v1alpha1
 kind: FlinkApplication
 metadata:
   name: wordcount-operator-example
-  namespace: default
+  namespace: flink-operator
   annotations:
   labels:
     environment: development

--- a/examples/wordcount/flink-operator-custom-resource.yaml
+++ b/examples/wordcount/flink-operator-custom-resource.yaml
@@ -2,6 +2,7 @@ apiVersion: flink.k8s.io/v1alpha1
 kind: FlinkApplication
 metadata:
   name: wordcount-operator-example
+  namespace: default
   annotations:
   labels:
     environment: development
@@ -28,4 +29,3 @@ spec:
   jarName: "wordcount-operator-example-1.0.0-SNAPSHOT.jar"
   parallelism: 3
   entryClass: "org.apache.flink.WordCount"
-

--- a/integ/operator-test-app/flink-conf.yaml
+++ b/integ/operator-test-app/flink-conf.yaml
@@ -1,8 +1,6 @@
 jobmanager.web.submit.enable: true
 jobmanager.web.log.path: /var/log/jobmanager/current
 
-jobmanager.web.upload.dir: /opt/flink
-
 taskmanager.log.path: /var/log/taskmanager/current
 taskmanager.exit-on-fatal-akka-error: true
 taskmanager.network.memory.max: 2147483648
@@ -11,6 +9,8 @@ taskmanager.network.memory.fraction: 0.125
 # Akka config
 akka.framesize: 20MB
 parallelism.default: 1
+
+web.upload.dir: /opt/flink
 
 # State backend config
 state.backend: rocksdb


### PR DESCRIPTION
1. Updated Go to the most recent version (i.e. 1.12.5). 1.10.4 is way too old.
2. Updated the URL for S2I. The previous URL was pointing to a location that redirected to the current URL.
3. It's always good to specify the namespace for a namespaced resource. So a namespace `default` is added to the sample FlinkApplication YAML and READMEs are updated accordingly. Previously, without namespace specified, the CR object was also created in `default` namespace by default. But the README was assuming it was in the `flink-operator` namespace.
4. Changed `jobmanager.web.upload.dir` to `web.upload.dir`. The former is now deprecated.