### PR TITLE
Handle invalid phases in the Flink state machine

### DIFF
--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -98,6 +98,11 @@ func (s *FlinkStateMachine) shouldRollback(ctx context.Context, application *v1a
 
 func (s *FlinkStateMachine) Handle(ctx context.Context, application *v1alpha1.FlinkApplication) error {
 	currentPhase := application.Status.Phase
+	if _, ok := s.metrics.stateMachineHandlePhaseMap[currentPhase]; !ok {
+		errMsg := fmt.Sprintf("Invalid state %s for the application", currentPhase)
+		logger.Errorf(ctx, errMsg)
+		return errors.New(errMsg)
+	}
 	timer := s.metrics.stateMachineHandlePhaseMap[currentPhase].Start(ctx)
 	successTimer := s.metrics.stateMachineHandleSuccessPhaseMap[currentPhase].Start(ctx)
 

--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -100,7 +100,6 @@ func (s *FlinkStateMachine) Handle(ctx context.Context, application *v1alpha1.Fl
 	currentPhase := application.Status.Phase
 	if _, ok := s.metrics.stateMachineHandlePhaseMap[currentPhase]; !ok {
 		errMsg := fmt.Sprintf("Invalid state %s for the application", currentPhase)
-		logger.Errorf(ctx, errMsg)
 		return errors.New(errMsg)
 	}
 	timer := s.metrics.stateMachineHandlePhaseMap[currentPhase].Start(ctx)

--- a/pkg/controller/flinkapplication/flink_state_machine_test.go
+++ b/pkg/controller/flinkapplication/flink_state_machine_test.go
@@ -848,3 +848,16 @@ func TestDeleteModeNone(t *testing.T) {
 	assert.Equal(t, 2, updateCount)
 	assert.False(t, cancelled)
 }
+
+func TestHandleInvalidPhase(t *testing.T) {
+	stateMachineForTest := getTestStateMachine()
+
+	err := stateMachineForTest.Handle(context.Background(), &v1alpha1.FlinkApplication{
+		Spec: v1alpha1.FlinkApplicationSpec{},
+		Status: v1alpha1.FlinkApplicationStatus{
+			Phase: "asd",
+		},
+	})
+	assert.NotNil(t, err)
+	assert.EqualError(t, err, "Invalid state asd for the application")
+}


### PR DESCRIPTION
The operator currently panics if it receives an application callback with an invalid phase.