### PR TITLE
Fix Resty logging, timeout and retry configuration

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -326,7 +326,7 @@
   version = "v0.1.10"
 
 [[projects]]
-  digest = "1:9cffbffa7a28b8ff338fbd9f5f02d71f244de71e612f0d9ac3aaa6361e1dd1cf"
+  digest = "1:cd575a47d4c9a2e479495f8a28f7143e8188caff0692cf11ab23cf0d81a36d6d"
   name = "github.com/lyft/flytestdlib"
   packages = [
     "atomic",
@@ -341,8 +341,8 @@
     "version",
   ]
   pruneopts = ""
-  revision = "b3fb6d180b31876e4ebd7fcf9023af3a0bddd630"
-  version = "v0.2.6"
+  revision = "755b546c3c88971ffeadf298d53853c4b759d087"
+  version = "v0.2.8"
 
 [[projects]]
   digest = "1:ae39921edb7f801f7ce1b6b5484f9715a1dd2b52cb645daef095cd10fd6ee774"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -36,4 +36,4 @@ required = [
 
 [[constraint]]
   name = "github.com/lyft/flytestdlib"
-  version = "0.2.6"
+  version = "0.2.8"

--- a/pkg/controller/flink/client/api_test.go
+++ b/pkg/controller/flink/client/api_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/go-resty/resty"
 	"github.com/jarcoal/httpmock"
 	mockScope "github.com/lyft/flytestdlib/promutils"
 	"github.com/lyft/flytestdlib/promutils/labeled"
@@ -27,10 +26,7 @@ const fakeCancelURL = "http://abc.com/jobs/1/savepoints"
 const fakeTaskmanagersURL = "http://abc.com/taskmanagers"
 
 func getTestClient() FlinkJobManagerClient {
-	client := resty.SetRetryCount(1)
-	return FlinkJobManagerClient{
-		client: client,
-	}
+	return FlinkJobManagerClient{}
 }
 
 func getTestJobManagerClient() FlinkAPIInterface {
@@ -438,7 +434,7 @@ func TestClientInvalidMethod(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	client := getTestClient()
-	_, err := client.executeRequest("random", testURL, nil)
+	_, err := client.executeRequest(context.Background(), "random", testURL, nil)
 	assert.NotNil(t, err)
 	assert.EqualError(t, err, "Invalid method random in request")
 }


### PR DESCRIPTION
- Fixes the incorrect logging from Resty library.
- Removes retry from Patch and Post requests, as Flink POST request is not idempotent.
- Separate timeout for Get vs Post request.

Sample logs in json format: 
```
{"json":{"app_name":"taskfailurejob","ns":"default","phase":"SubmittingJob","src":"api.go:147"},"level":"info","msg":"RESTY 2019/06/14 13:48:18 ERROR Get http://localhost:8001/api/v1/namespaces/default/services/taskfailurejob-949b65b0:8081/proxy/overview: dial tcp [::1]:8001: connect: connection refused, Attempt 3","ts":"2019-06-14T13:48:18-07:00"}
{"json":{"app_name":"taskfailurejob","ns":"default","phase":"SubmittingJob","src":"api.go:147"},"level":"info","msg":"RESTY 2019/06/14 13:48:18 ERROR Get http://localhost:8001/api/v1/namespaces/flink-operator/services/wordcount-operator-example-c931dcc2:8081/proxy/overview: dial tcp [::1]:8001: connect: connection refused, Attempt 3","ts":"2019-06-14T13:48:18-07:00"}
```