### PR TITLE
[STRMCMP-544] Allow FlinkApplications to be deleted when job submission fails

### DIFF
--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -528,13 +528,13 @@ func (s *FlinkStateMachine) handleApplicationDeleting(ctx context.Context, app *
 		return err
 	}
 
-	if len(jobs) == 0 {
-		// there are no jobs for this application -- this means that the job either finished or was manually cancelled
-		// _and_ the job manager was restarted
+	finished := jobFinished(jobs, app.Status.JobStatus.JobID)
+
+	if len(jobs) == 0 || finished {
+		// there are no running jobs for this application, we can just tear down
 		return s.clearFinalizers(ctx, app)
 	}
 
-	finished := jobFinished(jobs, app.Status.JobStatus.JobID)
 	switch app.Spec.DeleteMode {
 	case v1alpha1.DeleteModeForceCancel:
 		if finished {

--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -537,18 +537,10 @@ func (s *FlinkStateMachine) handleApplicationDeleting(ctx context.Context, app *
 
 	switch app.Spec.DeleteMode {
 	case v1alpha1.DeleteModeForceCancel:
-		if finished {
-			// the job has already been cancelled, so clear the finalizer
-			return s.clearFinalizers(ctx, app)
-		}
-
 		logger.Infof(ctx, "Force cancelling job as part of cleanup")
 		return s.flinkController.ForceCancel(ctx, app, app.Status.DeployHash)
 	case v1alpha1.DeleteModeSavepoint, "":
 		if app.Spec.SavepointInfo.SavepointLocation != "" {
-			if finished {
-				return s.clearFinalizers(ctx, app)
-			}
 			// we've already created the savepoint, now just waiting for the job to be cancelled
 			return nil
 		}

--- a/pkg/controller/flinkapplication/flink_state_machine_test.go
+++ b/pkg/controller/flinkapplication/flink_state_machine_test.go
@@ -646,6 +646,7 @@ func TestDeleteWithSavepoint(t *testing.T) {
 		},
 		Status: v1alpha1.FlinkApplicationStatus{
 			Phase: v1alpha1.FlinkApplicationDeleting,
+			DeployHash: "deployhash",
 			JobStatus: v1alpha1.FlinkJobStatus{
 				JobID: jobID,
 			},
@@ -741,6 +742,7 @@ func TestDeleteWithForceCancel(t *testing.T) {
 			JobStatus: v1alpha1.FlinkJobStatus{
 				JobID: jobID,
 			},
+			DeployHash: "deployhash",
 		},
 	}
 

--- a/pkg/controller/flinkapplication/flink_state_machine_test.go
+++ b/pkg/controller/flinkapplication/flink_state_machine_test.go
@@ -724,6 +724,50 @@ func TestDeleteWithSavepoint(t *testing.T) {
 
 }
 
+func TestDeleteWithSavepointAndFinishedJob(t *testing.T) {
+	stateMachineForTest := getTestStateMachine()
+	jobID := "j1"
+
+	app := v1alpha1.FlinkApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Finalizers:        []string{jobFinalizer},
+			DeletionTimestamp: &metav1.Time{Time: time.Now()},
+		},
+		Status: v1alpha1.FlinkApplicationStatus{
+			Phase:      v1alpha1.FlinkApplicationDeleting,
+			DeployHash: "deployhash",
+			JobStatus: v1alpha1.FlinkJobStatus{
+				JobID: jobID,
+			},
+		},
+	}
+
+	mockFlinkController := stateMachineForTest.flinkController.(*mock.FlinkController)
+
+	mockFlinkController.GetJobsForApplicationFunc = func(ctx context.Context, application *v1alpha1.FlinkApplication, hash string) (jobs []client.FlinkJob, err error) {
+		return []client.FlinkJob{
+			{
+				JobID:  jobID,
+				Status: "FINISHED",
+			},
+		}, nil
+	}
+
+	mockK8Cluster := stateMachineForTest.k8Cluster.(*k8mock.K8Cluster)
+
+	mockK8Cluster.UpdateK8ObjectFunc = func(ctx context.Context, object runtime.Object) error {
+		application := object.(*v1alpha1.FlinkApplication)
+		assert.Equal(t, v1alpha1.FlinkApplicationDeleting, application.Status.Phase)
+
+		assert.Equal(t, 0, len(app.Finalizers))
+
+		return nil
+	}
+
+	err := stateMachineForTest.Handle(context.Background(), &app)
+	assert.NoError(t, err)
+}
+
 func TestDeleteWithForceCancel(t *testing.T) {
 	stateMachineForTest := getTestStateMachine()
 

--- a/pkg/controller/flinkapplication/flink_state_machine_test.go
+++ b/pkg/controller/flinkapplication/flink_state_machine_test.go
@@ -645,7 +645,7 @@ func TestDeleteWithSavepoint(t *testing.T) {
 			DeletionTimestamp: &metav1.Time{Time: time.Now()},
 		},
 		Status: v1alpha1.FlinkApplicationStatus{
-			Phase: v1alpha1.FlinkApplicationDeleting,
+			Phase:      v1alpha1.FlinkApplicationDeleting,
 			DeployHash: "deployhash",
 			JobStatus: v1alpha1.FlinkJobStatus{
 				JobID: jobID,


### PR DESCRIPTION
Currently, if a user creates a new FlinkApplication for which we can't successfully submit the job (e.g., the jar name is wrong, the job crashes on startup, the specified savepoint doesn't exist, etc.) the user will not be able to then delete the FlinkApplication without changing the DeleteMode to None. This is because we do not set the DeployHash until after job submission, which prevents us from querying the versioned cluster. This PR addresses that by allowing immediate deletion of a cluster when the DeployHash is not set.

It also addresses the issue in #13 by allowing deletion when there has been a successful deploy at some point, but at delete time no jobs are running.