### PR TITLE
Use EventRecorder instead of emitting events manually

### DIFF
--- a/cmd/flinkk8soperator/cmd/root.go
+++ b/cmd/flinkk8soperator/cmd/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/lyft/flinkk8soperator/pkg/controller"
-	controller_config "github.com/lyft/flinkk8soperator/pkg/controller/config"
+	controllerConfig "github.com/lyft/flinkk8soperator/pkg/controller/config"
 	ctrlRuntimeConfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	"github.com/kubernetes-sigs/controller-runtime/pkg/runtime/signals"
@@ -27,10 +27,6 @@ import (
 	"github.com/lyft/flytestdlib/promutils/labeled"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-)
-
-const (
-	appName = "flinkk8soperator"
 )
 
 var (
@@ -46,27 +42,27 @@ var rootCmd = &cobra.Command{
 		return initConfig(cmd.Flags())
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return executeRootCmd(controller_config.GetConfig())
+		return executeRootCmd(controllerConfig.GetConfig())
 	},
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	version.LogBuildInformation(appName)
+	version.LogBuildInformation(controllerConfig.AppName)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 }
 
-func Run(config *controller_config.Config) error {
-	if err := controller_config.SetConfig(config); err != nil {
+func Run(config *controllerConfig.Config) error {
+	if err := controllerConfig.SetConfig(config); err != nil {
 		logger.Errorf(context.Background(), "Failed to set config: %v", err)
 		return err
 	}
 
-	return executeRootCmd(controller_config.GetConfig())
+	return executeRootCmd(controllerConfig.GetConfig())
 }
 
 func init() {
@@ -104,7 +100,7 @@ func logAndExit(err error) {
 	os.Exit(-1)
 }
 
-func executeRootCmd(controllerCfg *controller_config.Config) error {
+func executeRootCmd(controllerCfg *controllerConfig.Config) error {
 	ctx, cancelNow := context.WithCancel(context.Background())
 
 	labeled.SetMetricKeys(common.GetValidLabelNames()...)
@@ -141,7 +137,7 @@ func executeRootCmd(controllerCfg *controller_config.Config) error {
 }
 
 func operatorEntryPoint(ctx context.Context, metricsScope promutils.Scope,
-	controllerCfg *controller_config.Config) (stopCh <-chan struct{}, err error) {
+	controllerCfg *controllerConfig.Config) (stopCh <-chan struct{}, err error) {
 
 	// Get a config to talk to the apiserver
 	cfg, err := ctrlRuntimeConfig.GetConfig()
@@ -167,7 +163,7 @@ func operatorEntryPoint(ctx context.Context, metricsScope promutils.Scope,
 
 	// Setup all Controllers
 	logger.Infof(ctx, "Adding controllers.")
-	if err := controller.AddToManager(ctx, mgr, controller_config.RuntimeConfig{
+	if err := controller.AddToManager(ctx, mgr, controllerConfig.RuntimeConfig{
 		MetricsScope: metricsScope,
 	}); err != nil {
 		return nil, err

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -6,6 +6,7 @@ import (
 
 //go:generate pflags Config
 
+const AppName = "flinkK8sOperator"
 const configSectionKey = "operator"
 
 var ConfigSection = config.MustRegisterSection(configSectionKey, &Config{})

--- a/pkg/controller/flink/flink_test.go
+++ b/pkg/controller/flink/flink_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/lyft/flinkk8soperator/pkg/client/clientset/versioned/scheme"
+	"k8s.io/client-go/tools/record"
+
 	"time"
 
 	"github.com/lyft/flinkk8soperator/pkg/apis/app/v1alpha1"
@@ -35,12 +38,16 @@ const testFlinkVersion = "1.7"
 func getTestFlinkController() Controller {
 	testScope := mockScope.NewTestScope()
 	labeled.SetMetricKeys(common.GetValidLabelNames()...)
+
+	recorderProvider := record.NewBroadcaster()
+
 	return Controller{
-		jobManager:  &mock.JobManagerController{},
-		taskManager: &mock.TaskManagerController{},
-		k8Cluster:   &k8mock.K8Cluster{},
-		flinkClient: &clientMock.JobManagerClient{},
-		metrics:     newControllerMetrics(testScope),
+		jobManager:    &mock.JobManagerController{},
+		taskManager:   &mock.TaskManagerController{},
+		k8Cluster:     &k8mock.K8Cluster{},
+		flinkClient:   &clientMock.JobManagerClient{},
+		metrics:       newControllerMetrics(testScope),
+		eventRecorder: recorderProvider.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "test"}),
 	}
 }
 

--- a/pkg/controller/flink/mock/mock_flink.go
+++ b/pkg/controller/flink/mock/mock_flink.go
@@ -6,7 +6,6 @@ import (
 	"github.com/lyft/flinkk8soperator/pkg/apis/app/v1alpha1"
 	"github.com/lyft/flinkk8soperator/pkg/controller/common"
 	"github.com/lyft/flinkk8soperator/pkg/controller/flink/client"
-	"github.com/lyft/flinkk8soperator/pkg/controller/k8"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -120,8 +119,17 @@ func (m *FlinkController) FindExternalizedCheckpoint(ctx context.Context, applic
 	return "", nil
 }
 
-func (m *FlinkController) LogEvent(ctx context.Context, app *v1alpha1.FlinkApplication, fieldPath string, eventType string, message string) {
-	m.Events = append(m.Events, k8.CreateEvent(app, fieldPath, eventType, "Test", message))
+func (m *FlinkController) LogEvent(ctx context.Context, app *v1alpha1.FlinkApplication, eventType string, message string) {
+	m.Events = append(m.Events, corev1.Event{
+		InvolvedObject: corev1.ObjectReference{
+			Kind:      app.Kind,
+			Name:      app.Name,
+			Namespace: app.Namespace,
+		},
+		Type:    eventType,
+		Reason:  "Test",
+		Message: message,
+	})
 }
 
 func (m *FlinkController) CompareAndUpdateClusterStatus(ctx context.Context, application *v1alpha1.FlinkApplication, hash string) (bool, error) {

--- a/pkg/controller/flinkapplication/controller.go
+++ b/pkg/controller/flinkapplication/controller.go
@@ -117,7 +117,7 @@ func (r *ReconcileFlinkApplication) Reconcile(request reconcile.Request) (reconc
 // and Start it when the Manager is Started.
 func Add(ctx context.Context, mgr manager.Manager, cfg config.RuntimeConfig) error {
 	k8sCluster := k8.NewK8Cluster(mgr)
-	flinkStateMachine := NewFlinkStateMachine(k8sCluster, cfg)
+	flinkStateMachine := NewFlinkStateMachine(k8sCluster, mgr, cfg)
 
 	metrics := newReconcilerMetrics(cfg.MetricsScope)
 	reconciler := ReconcileFlinkApplication{
@@ -127,7 +127,7 @@ func Add(ctx context.Context, mgr manager.Manager, cfg config.RuntimeConfig) err
 		flinkStateMachine: flinkStateMachine,
 	}
 
-	c, err := controller.New("flinkAppController", mgr, controller.Options{
+	c, err := controller.New(config.AppName, mgr, controller.Options{
 		MaxConcurrentReconciles: config.GetConfig().Workers,
 		Reconciler:              &reconciler,
 	})

--- a/pkg/controller/k8/utils.go
+++ b/pkg/controller/k8/utils.go
@@ -1,11 +1,8 @@
 package k8
 
 import (
-	"github.com/lyft/flinkk8soperator/pkg/apis/app/v1alpha1"
 	v1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -32,38 +29,4 @@ func GetDeploymentWithName(deployments []v1.Deployment, name string) *v1.Deploym
 		}
 	}
 	return nil
-}
-
-func CreateEvent(app *v1alpha1.FlinkApplication, fieldPath string, eventType string, reason string, message string) corev1.Event {
-	eventTime := metav1.Now()
-
-	objectReference := corev1.ObjectReference{
-		Kind:       app.Kind,
-		Name:       app.Name,
-		Namespace:  app.Namespace,
-		UID:        app.UID,
-		APIVersion: app.APIVersion,
-		FieldPath:  fieldPath,
-	}
-
-	return corev1.Event{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: corev1.SchemeGroupVersion.String(),
-			Kind:       "Event",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:    app.Namespace,
-			GenerateName: "event",
-		},
-		Reason:         reason,
-		Message:        message,
-		InvolvedObject: objectReference,
-		Source: corev1.EventSource{
-			Component: "flinkk8soperator",
-		},
-		FirstTimestamp: eventTime,
-		LastTimestamp:  eventTime,
-		Type:           eventType,
-	}
-
 }


### PR DESCRIPTION
This replaces the current implementation of creating events manually through the Client.

```
  Type    Reason  Age   From              Message
  ----    ------  ----  ----              -------
  Normal  Create  32s   flinkK8sOperator  Flink cluster created
  Normal  Create  20s   flinkK8sOperator  Flink job submitted to cluster with id 519428ccbadc58365924f1bba55324b1
  Normal  Update  14s   flinkK8sOperator  Flink cluster created
  Type    Reason  Age   From              Message
  ----    ------  ----  ----              -------
  Normal  Create  34s   flinkK8sOperator  Flink cluster created
  Normal  Create  22s   flinkK8sOperator  Flink job submitted to cluster with id 519428ccbadc58365924f1bba55324b1
  Normal  Update  16s   flinkK8sOperator  Flink cluster created```