### PR TITLE
Update logic around number and healthy task managers in status

### DIFF
--- a/pkg/controller/flink/flink_test.go
+++ b/pkg/controller/flink/flink_test.go
@@ -72,10 +72,10 @@ func TestFlinkIsClusterReady(t *testing.T) {
 	mockK8Cluster.GetDeploymentsWithLabelFunc = func(ctx context.Context, namespace string, labelMap map[string]string) (*v1.DeploymentList, error) {
 		assert.Equal(t, testNamespace, namespace)
 		assert.Equal(t, labelMapVal, labelMap)
-		jmDeployment := FetchTaskMangerDeploymentCreateObj(&flinkApp, testAppHash)
+		jmDeployment := FetchJobMangerDeploymentCreateObj(&flinkApp, testAppHash)
 		jmDeployment.Status.AvailableReplicas = 1
 
-		tmDeployment := FetchJobMangerDeploymentCreateObj(&flinkApp, testAppHash)
+		tmDeployment := FetchTaskMangerDeploymentCreateObj(&flinkApp, testAppHash)
 		tmDeployment.Status.AvailableReplicas = *tmDeployment.Spec.Replicas
 		return &v1.DeploymentList{
 			Items: []v1.Deployment{
@@ -555,6 +555,25 @@ func TestClusterStatusUpdated(t *testing.T) {
 	flinkControllerForTest := getTestFlinkController()
 	flinkApp := getFlinkTestApp()
 
+	labelMapVal := map[string]string{
+		"flink-app-hash": testAppHash,
+	}
+	mockK8Cluster := flinkControllerForTest.k8Cluster.(*k8mock.K8Cluster)
+	mockK8Cluster.GetDeploymentsWithLabelFunc = func(ctx context.Context, namespace string, labelMap map[string]string) (*v1.DeploymentList, error) {
+		assert.Equal(t, testNamespace, namespace)
+		assert.Equal(t, labelMapVal, labelMap)
+
+		tmDeployment := FetchTaskMangerDeploymentCreateObj(&flinkApp, testAppHash)
+		tmDeployment.Status.AvailableReplicas = *tmDeployment.Spec.Replicas
+		tmDeployment.Status.Replicas = *tmDeployment.Spec.Replicas
+
+		return &v1.DeploymentList{
+			Items: []v1.Deployment{
+				*tmDeployment,
+			},
+		}, nil
+	}
+
 	mockJmClient := flinkControllerForTest.flinkClient.(*clientMock.JobManagerClient)
 	mockJmClient.GetClusterOverviewFunc = func(ctx context.Context, url string) (*client.ClusterOverviewResponse, error) {
 		assert.Equal(t, url, "http://app-name-hash.ns:8081")
@@ -595,6 +614,19 @@ func TestNoClusterStatusChange(t *testing.T) {
 	flinkApp.Status.ClusterStatus.HealthyTaskManagers = int32(1)
 	flinkApp.Status.ClusterStatus.Health = v1alpha1.Green
 	flinkApp.Status.ClusterStatus.NumberOfTaskManagers = int32(1)
+	mockK8Cluster := flinkControllerForTest.k8Cluster.(*k8mock.K8Cluster)
+	mockK8Cluster.GetDeploymentsWithLabelFunc = func(ctx context.Context, namespace string, labelMap map[string]string) (*v1.DeploymentList, error) {
+		tmDeployment := FetchTaskMangerDeploymentCreateObj(&flinkApp, testAppHash)
+		tmDeployment.Status.AvailableReplicas = 1
+		tmDeployment.Status.Replicas = 1
+
+		return &v1.DeploymentList{
+			Items: []v1.Deployment{
+				*tmDeployment,
+			},
+		}, nil
+	}
+
 	mockJmClient := flinkControllerForTest.flinkClient.(*clientMock.JobManagerClient)
 	mockJmClient.GetClusterOverviewFunc = func(ctx context.Context, url string) (*client.ClusterOverviewResponse, error) {
 		assert.Equal(t, url, "http://app-name-hash.ns:8081")
@@ -617,7 +649,6 @@ func TestNoClusterStatusChange(t *testing.T) {
 			},
 		}, nil
 	}
-
 	hasClusterStatusChanged, err := flinkControllerForTest.CompareAndUpdateClusterStatus(context.Background(), &flinkApp, "hash")
 	assert.Nil(t, err)
 	assert.False(t, hasClusterStatusChanged)
@@ -626,6 +657,19 @@ func TestNoClusterStatusChange(t *testing.T) {
 func TestHealthyTaskmanagers(t *testing.T) {
 	flinkControllerForTest := getTestFlinkController()
 	flinkApp := getFlinkTestApp()
+
+	mockK8Cluster := flinkControllerForTest.k8Cluster.(*k8mock.K8Cluster)
+	mockK8Cluster.GetDeploymentsWithLabelFunc = func(ctx context.Context, namespace string, labelMap map[string]string) (*v1.DeploymentList, error) {
+		tmDeployment := FetchTaskMangerDeploymentCreateObj(&flinkApp, testAppHash)
+		tmDeployment.Status.AvailableReplicas = 1
+		tmDeployment.Status.Replicas = 1
+
+		return &v1.DeploymentList{
+			Items: []v1.Deployment{
+				*tmDeployment,
+			},
+		}, nil
+	}
 
 	mockJmClient := flinkControllerForTest.flinkClient.(*clientMock.JobManagerClient)
 

--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -340,6 +340,12 @@ func (s *FlinkStateMachine) handleSubmittingJob(ctx context.Context, app *v1alph
 		return err
 	}
 
+	// Update status of the cluster
+	_, clusterErr := s.flinkController.CompareAndUpdateClusterStatus(ctx, app, hash)
+	if clusterErr != nil {
+		logger.Errorf(ctx, "Updating cluster status failed with error: %v", clusterErr)
+	}
+
 	activeJob, err := s.submitJobIfNeeded(ctx, app, hash,
 		app.Spec.JarName, app.Spec.Parallelism, app.Spec.EntryClass, app.Spec.ProgramArgs)
 	if err != nil {


### PR DESCRIPTION
New Logic:
 - Uses the value of availableReplicas to update `NumberOfTaskManagers`
 - `HealthyTaskManagers` is still obtained from the API response
 - Health logic is now compared between `HealthyTaskManagers`, and number of replicas expected.

Cluster status is also updated when in `SubmittingJob` state.
Not updating the ClusterStatus in `ClusterStarting`, as there could be multiple clusters, and hence removed the check.