### PR TITLE
Add support for non restored state on job submission

### DIFF
--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -49,6 +49,8 @@ spec:
             deleteMode:
               type: string
               enum: [Savepoint, None, ForceCancel]
+            allowNonRestoredState:
+              type: boolean
             deploymentMode:
               type: string
               enum: [Dual]
@@ -110,7 +112,7 @@ spec:
                                   name:
                                     type: string
                                   optional:
-                                    type: boolean
+                                 f   type: boolean
                                 required:
                                   - key
                                 type: object

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -112,7 +112,7 @@ spec:
                                   name:
                                     type: string
                                   optional:
-                                 f   type: boolean
+                                    type: boolean
                                 required:
                                   - key
                                 type: object

--- a/docs/crd.md
+++ b/docs/crd.md
@@ -71,7 +71,7 @@ Below is the list of fields in the custom resource and their description
   * **ProgramArgs** `type:string`
     External configuration parameters to be passed as arguments to the job like input and output sources, etc
     
-  * **AllowNonRestoredSavepoint** `type:boolean`
+  * **AllowNonRestoredState** `type:boolean`
     Skips savepoint operator state that cannot be mapped to the new program version  
 
   * **SavepointInfo** `type:SavepointInfo`

--- a/docs/crd.md
+++ b/docs/crd.md
@@ -70,6 +70,9 @@ Below is the list of fields in the custom resource and their description
 
   * **ProgramArgs** `type:string`
     External configuration parameters to be passed as arguments to the job like input and output sources, etc
+    
+  * **AllowNonRestoredSavepoint** `type:boolean`
+    Skips savepoint operator state that cannot be mapped to the new program version  
 
   * **SavepointInfo** `type:SavepointInfo`
     Optional Savepoint info that can be passed in to indicate that the Flink job must resume from the corresponding savepoint.

--- a/pkg/apis/app/v1alpha1/types.go
+++ b/pkg/apis/app/v1alpha1/types.go
@@ -28,28 +28,29 @@ type FlinkApplication struct {
 }
 
 type FlinkApplicationSpec struct {
-	Image             string                       `json:"image,omitempty" protobuf:"bytes,2,opt,name=image"`
-	ImagePullPolicy   apiv1.PullPolicy             `json:"imagePullPolicy,omitempty" protobuf:"bytes,14,opt,name=imagePullPolicy,casttype=PullPolicy"`
-	ImagePullSecrets  []apiv1.LocalObjectReference `json:"imagePullSecrets,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,15,rep,name=imagePullSecrets"`
-	FlinkConfig       FlinkConfig                  `json:"flinkConfig"`
-	FlinkVersion      string                       `json:"flinkVersion"`
-	TaskManagerConfig TaskManagerConfig            `json:"taskManagerConfig,omitempty"`
-	JobManagerConfig  JobManagerConfig             `json:"jobManagerConfig,omitempty"`
-	JarName           string                       `json:"jarName"`
-	Parallelism       int32                        `json:"parallelism"`
-	EntryClass        string                       `json:"entryClass,omitempty"`
-	ProgramArgs       string                       `json:"programArgs,omitempty"`
-	SavepointInfo     SavepointInfo                `json:"savepointInfo,omitempty"`
-	DeploymentMode    DeploymentMode               `json:"deploymentMode,omitempty"`
-	RPCPort           *int32                       `json:"rpcPort,omitempty"`
-	BlobPort          *int32                       `json:"blobPort,omitempty"`
-	QueryPort         *int32                       `json:"queryPort,omitempty"`
-	UIPort            *int32                       `json:"uiPort,omitempty"`
-	MetricsQueryPort  *int32                       `json:"metricsQueryPort,omitempty"`
-	Volumes           []apiv1.Volume               `json:"volumes,omitempty"`
-	VolumeMounts      []apiv1.VolumeMount          `json:"volumeMounts,omitempty"`
-	RestartNonce      string                       `json:"restartNonce"`
-	DeleteMode        DeleteMode                   `json:"deleteMode,omitempty"`
+	Image                 string                       `json:"image,omitempty" protobuf:"bytes,2,opt,name=image"`
+	ImagePullPolicy       apiv1.PullPolicy             `json:"imagePullPolicy,omitempty" protobuf:"bytes,14,opt,name=imagePullPolicy,casttype=PullPolicy"`
+	ImagePullSecrets      []apiv1.LocalObjectReference `json:"imagePullSecrets,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,15,rep,name=imagePullSecrets"`
+	FlinkConfig           FlinkConfig                  `json:"flinkConfig"`
+	FlinkVersion          string                       `json:"flinkVersion"`
+	TaskManagerConfig     TaskManagerConfig            `json:"taskManagerConfig,omitempty"`
+	JobManagerConfig      JobManagerConfig             `json:"jobManagerConfig,omitempty"`
+	JarName               string                       `json:"jarName"`
+	Parallelism           int32                        `json:"parallelism"`
+	EntryClass            string                       `json:"entryClass,omitempty"`
+	ProgramArgs           string                       `json:"programArgs,omitempty"`
+	SavepointInfo         SavepointInfo                `json:"savepointInfo,omitempty"`
+	DeploymentMode        DeploymentMode               `json:"deploymentMode,omitempty"`
+	RPCPort               *int32                       `json:"rpcPort,omitempty"`
+	BlobPort              *int32                       `json:"blobPort,omitempty"`
+	QueryPort             *int32                       `json:"queryPort,omitempty"`
+	UIPort                *int32                       `json:"uiPort,omitempty"`
+	MetricsQueryPort      *int32                       `json:"metricsQueryPort,omitempty"`
+	Volumes               []apiv1.Volume               `json:"volumes,omitempty"`
+	VolumeMounts          []apiv1.VolumeMount          `json:"volumeMounts,omitempty"`
+	RestartNonce          string                       `json:"restartNonce"`
+	DeleteMode            DeleteMode                   `json:"deleteMode,omitempty"`
+	AllowNonRestoredState bool                         `json:"allowNonRestoredState,omitempty"`
 }
 
 type FlinkConfig map[string]interface{}

--- a/pkg/controller/flink/client/entities.go
+++ b/pkg/controller/flink/client/entities.go
@@ -37,10 +37,11 @@ type CancelJobRequest struct {
 }
 
 type SubmitJobRequest struct {
-	SavepointPath string `json:"savepointPath"`
-	Parallelism   int32  `json:"parallelism"`
-	ProgramArgs   string `json:"programArgs"`
-	EntryClass    string `json:"entryClass"`
+	SavepointPath         string `json:"savepointPath"`
+	Parallelism           int32  `json:"parallelism"`
+	ProgramArgs           string `json:"programArgs"`
+	EntryClass            string `json:"entryClass"`
+	AllowNonRestoredState bool   `json:"allowNonRestoredState"`
 }
 
 type SavepointResponse struct {

--- a/pkg/controller/flink/flink.go
+++ b/pkg/controller/flink/flink.go
@@ -377,7 +377,7 @@ func (f *Controller) DeleteOldResourcesForApp(ctx context.Context, app *v1alpha1
 	for _, d := range deployments.Items {
 		if d.Labels[FlinkAppHash] != "" &&
 			d.Labels[FlinkAppHash] != curHash &&
-		// verify that this deployment matches the jobmanager or taskmanager naming format
+			// verify that this deployment matches the jobmanager or taskmanager naming format
 			(d.Name == fmt.Sprintf(JobManagerNameFormat, app.Name, d.Labels[FlinkAppHash]) ||
 				d.Name == fmt.Sprintf(TaskManagerNameFormat, app.Name, d.Labels[FlinkAppHash])) {
 			oldObjects = append(oldObjects, d.DeepCopy())

--- a/pkg/controller/flink/flink.go
+++ b/pkg/controller/flink/flink.go
@@ -245,10 +245,11 @@ func (f *Controller) StartFlinkJob(ctx context.Context, application *v1alpha1.Fl
 		getURLFromApp(application, hash),
 		jarName,
 		client.SubmitJobRequest{
-			Parallelism:   parallelism,
-			SavepointPath: application.Spec.SavepointInfo.SavepointLocation,
-			EntryClass:    entryClass,
-			ProgramArgs:   programArgs,
+			Parallelism:           parallelism,
+			SavepointPath:         application.Spec.SavepointInfo.SavepointLocation,
+			EntryClass:            entryClass,
+			ProgramArgs:           programArgs,
+			AllowNonRestoredState: application.Spec.AllowNonRestoredState,
 		})
 	if err != nil {
 		return "", err
@@ -376,7 +377,7 @@ func (f *Controller) DeleteOldResourcesForApp(ctx context.Context, app *v1alpha1
 	for _, d := range deployments.Items {
 		if d.Labels[FlinkAppHash] != "" &&
 			d.Labels[FlinkAppHash] != curHash &&
-			// verify that this deployment matches the jobmanager or taskmanager naming format
+		// verify that this deployment matches the jobmanager or taskmanager naming format
 			(d.Name == fmt.Sprintf(JobManagerNameFormat, app.Name, d.Labels[FlinkAppHash]) ||
 				d.Name == fmt.Sprintf(TaskManagerNameFormat, app.Name, d.Labels[FlinkAppHash])) {
 			oldObjects = append(oldObjects, d.DeepCopy())

--- a/pkg/controller/flink/flink_test.go
+++ b/pkg/controller/flink/flink_test.go
@@ -436,6 +436,26 @@ func TestStartFlinkJob(t *testing.T) {
 		assert.Equal(t, submitJobRequest.ProgramArgs, "args")
 		assert.Equal(t, submitJobRequest.EntryClass, "class")
 		assert.Equal(t, submitJobRequest.SavepointPath, "location//")
+		assert.Equal(t, submitJobRequest.AllowNonRestoredState, false)
+
+		return &client.SubmitJobResponse{
+			JobID: testJobID,
+		}, nil
+	}
+	jobID, err := flinkControllerForTest.StartFlinkJob(context.Background(), &flinkApp, "hash",
+		flinkApp.Spec.JarName, flinkApp.Spec.Parallelism, flinkApp.Spec.EntryClass, flinkApp.Spec.ProgramArgs)
+	assert.Nil(t, err)
+	assert.Equal(t, jobID, testJobID)
+}
+
+func TestStartFlinkJobAllowNonRestoredState(t *testing.T) {
+	flinkControllerForTest := getTestFlinkController()
+	flinkApp := getFlinkTestApp()
+	flinkApp.Spec.AllowNonRestoredState = true
+
+	mockJmClient := flinkControllerForTest.flinkClient.(*clientMock.JobManagerClient)
+	mockJmClient.SubmitJobFunc = func(ctx context.Context, url string, jarID string, submitJobRequest client.SubmitJobRequest) (*client.SubmitJobResponse, error) {
+		assert.Equal(t, submitJobRequest.AllowNonRestoredState, true)
 
 		return &client.SubmitJobResponse{
 			JobID: testJobID,


### PR DESCRIPTION
This PR adds support for providing the `--allowNonRestoredState` flag to a submit job request. If, for some reason, that state isn't persistent between versions of a job, the deployment will fail entirely.

The addition here adds a `allowNonRestoredState` boolean flag to the `crd.yaml`.