### PR TITLE
Initialize Klog explicitly using InitFlags

### DIFF
--- a/cmd/flinkk8soperator/cmd/root.go
+++ b/cmd/flinkk8soperator/cmd/root.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"k8s.io/klog"
 	"os"
 	"strings"
+
+	"k8s.io/klog"
 
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 

--- a/cmd/flinkk8soperator/cmd/root.go
+++ b/cmd/flinkk8soperator/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"k8s.io/klog"
 	"os"
 	"strings"
 
@@ -71,6 +72,7 @@ func Run(config *controllerConfig.Config) error {
 func init() {
 	// See https://gist.github.com/nak3/78a32817a8a3950ae48f239a44cd3663
 	// allows `$ flinkoperator --logtostderr` to work
+	klog.InitFlags(nil)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	err := flag.CommandLine.Parse([]string{})
 	if err != nil {


### PR DESCRIPTION
Global flags have stopped working after [this change](https://github.com/lyft/flinkk8soperator/commit/f9206646aaffb7763657ec9e794bc979b0b4722b)
 
Use `klog.InitFlags(nil)` explicitly for initializing global flags as we no longer use `init()` method to register the flags

Refer here: https://github.com/kubernetes/klog/blob/master/README.md#how-to-use-klog


```aswaminathan-mbp151:flinkk8soperator aswaminathan$ go run cmd/flinkk8soperator/main.go  -h
Warn: No metricsProvider set for the workqueue
INFO[0000] ------------------------------------------------------------------------ 
INFO[0000] App [flinkK8sOperator], Version [unknown], BuildSHA [unknown], BuildTS [2019-07-08 12:27:54.869562 -0700 PDT m=+0.005832719] 
INFO[0000] ------------------------------------------------------------------------ 
Operator for running Flink applications in kubernetes

Usage:
  flinkoperator [flags]

Flags:
      --alsologtostderr                                 log to standard error as well as files
      --config string                                   config file path to load configuration
  -h, --help                                            help for flinkoperator
      --kubeconfig string                               Paths to a kubeconfig. Only required if out-of-cluster.
      --log_backtrace_at traceLocation                  when logging hits line file:N, emit a stack trace (default :0)
      --log_dir string                                  If non-empty, write log files in this directory
      --log_file string                                 If non-empty, use this log file
      --log_file_max_size uint                          Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
      --logger.formatter.type string                    Sets logging format type. (default "json")
      --logger.level int                                Sets the minimum logging level. (default 4)
      --logger.mute                                     Mutes all logs regardless of severity. Intended for benchmarks/tests only.
      --logger.show-source                              Includes source code location in logs.
      --logtostderr                                     log to standard error instead of files (default true)
      --master --kubeconfig                             (Deprecated: switch to --kubeconfig) The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.
      --operator.ProxyPort string                       The port at which flink cluster runs locally (default "8001")
      --operator.containerNameFormat string             
      --operator.ingressUrlFormat string                
      --operator.limitNamespace string                  Namespaces to watch for by flink operator
      --operator.metricsPrefix string                   Prefix for metrics propagated to prometheus (default "flinkk8soperator")
      --operator.prof-port string                       Profiler port (default "10254")
      --operator.resyncPeriod string                    Determines the resync period for all watchers. (default "30s")
      --operator.statemachineStalenessDuration string   Duration for statemachine staleness. (default "5m")
      --operator.useKubectlProxy                        
      --operator.workers int                            Number of routines to process custom resource (default 4)
      --skip_headers                                    If true, avoid header prefixes in the log messages
      --skip_log_headers                                If true, avoid headers when opening log files
      --stderrthreshold severity                        logs at or above this threshold go to stderr (default 2)
  -v, --v Level                                         number for the log level verbosity
      --vmodule moduleSpec                              comma-separated list of pattern=N settings for file-filtered logging```