### PR TITLE
Find the correct deployments for readiness and status checks

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -990,6 +990,7 @@
     "k8s.io/code-generator/cmd/informer-gen",
     "k8s.io/code-generator/cmd/lister-gen",
     "k8s.io/gengo/args",
+    "k8s.io/klog",
     "sigs.k8s.io/controller-runtime/pkg/cache",
     "sigs.k8s.io/controller-runtime/pkg/client",
     "sigs.k8s.io/controller-runtime/pkg/client/config",

--- a/pkg/controller/flink/container_utils.go
+++ b/pkg/controller/flink/container_utils.go
@@ -155,16 +155,6 @@ func HashForApplication(app *v1alpha1.FlinkApplication) string {
 	return fmt.Sprintf("%08x", hasher.Sum32())
 }
 
-func GetAppHashSelector(app *v1alpha1.FlinkApplication) map[string]string {
-	return GetAppHashSelectorWithHash(HashForApplication(app))
-}
-
-func GetAppHashSelectorWithHash(hash string) map[string]string {
-	return map[string]string{
-		FlinkAppHash: hash,
-	}
-}
-
 func InjectHashesIntoConfig(deployment *appsv1.Deployment, app *v1alpha1.FlinkApplication, hash string) {
 	var newContainers []v1.Container
 	for _, container := range deployment.Spec.Template.Spec.Containers {

--- a/pkg/controller/flink/flink_test.go
+++ b/pkg/controller/flink/flink_test.go
@@ -71,6 +71,7 @@ func getFlinkTestApp() v1alpha1.FlinkApplication {
 func TestFlinkIsClusterReady(t *testing.T) {
 	flinkControllerForTest := getTestFlinkController()
 	labelMapVal := map[string]string{
+		"flink-app":      testAppName,
 		"flink-app-hash": testAppHash,
 	}
 	flinkApp := getFlinkTestApp()
@@ -583,6 +584,7 @@ func TestClusterStatusUpdated(t *testing.T) {
 	flinkApp := getFlinkTestApp()
 
 	labelMapVal := map[string]string{
+		"flink-app":      testAppName,
 		"flink-app-hash": testAppHash,
 	}
 	mockK8Cluster := flinkControllerForTest.k8Cluster.(*k8mock.K8Cluster)
@@ -594,9 +596,12 @@ func TestClusterStatusUpdated(t *testing.T) {
 		tmDeployment.Status.AvailableReplicas = *tmDeployment.Spec.Replicas
 		tmDeployment.Status.Replicas = *tmDeployment.Spec.Replicas
 
+		jmDeployment := FetchJobMangerDeploymentCreateObj(&flinkApp, testAppHash)
+
 		return &v1.DeploymentList{
 			Items: []v1.Deployment{
 				*tmDeployment,
+				*jmDeployment,
 			},
 		}, nil
 	}
@@ -691,9 +696,12 @@ func TestHealthyTaskmanagers(t *testing.T) {
 		tmDeployment.Status.AvailableReplicas = 1
 		tmDeployment.Status.Replicas = 1
 
+		jmDeployment := FetchJobMangerDeploymentCreateObj(&flinkApp, testAppHash)
+
 		return &v1.DeploymentList{
 			Items: []v1.Deployment{
 				*tmDeployment,
+				*jmDeployment,
 			},
 		}, nil
 	}

--- a/pkg/controller/flink/job_manager_controller.go
+++ b/pkg/controller/flink/job_manager_controller.go
@@ -351,16 +351,3 @@ func JobManagerDeploymentMatches(deployment *v1.Deployment, application *v1alpha
 	deploymentFromApp := FetchJobMangerDeploymentCreateObj(application, HashForApplication(application))
 	return DeploymentsEqual(deploymentFromApp, deployment)
 }
-
-func getJobManagerCount(deployments []v1.Deployment, application *v1alpha1.FlinkApplication) int32 {
-	jobManagerDeployment := getJobManagerDeployment(deployments, application)
-	if jobManagerDeployment == nil {
-		return 0
-	}
-	return *jobManagerDeployment.Spec.Replicas
-}
-
-func getJobManagerDeployment(deployments []v1.Deployment, application *v1alpha1.FlinkApplication) *v1.Deployment {
-	jmDeploymentName := getJobManagerName(application, HashForApplication(application))
-	return k8.GetDeploymentWithName(deployments, jmDeploymentName)
-}

--- a/pkg/controller/flink/job_manager_controller_test.go
+++ b/pkg/controller/flink/job_manager_controller_test.go
@@ -40,28 +40,6 @@ func TestGetJobManagerPodName(t *testing.T) {
 	assert.Equal(t, "app-name-"+testAppHash+"-jm-pod", getJobManagerPodName(&app, testAppHash))
 }
 
-func TestGetJobManagerDeployment(t *testing.T) {
-	app := getFlinkTestApp()
-	deployment := v1.Deployment{}
-	deployment.Name = getJobManagerName(&app, testAppHash)
-	deployments := []v1.Deployment{
-		deployment,
-	}
-	assert.Equal(t, deployment, *getJobManagerDeployment(deployments, &app))
-}
-
-func TestGetJobManagerReplicaCount(t *testing.T) {
-	app := getFlinkTestApp()
-	deployment := v1.Deployment{}
-	deployment.Name = getJobManagerName(&app, HashForApplication(&app))
-	replicaCount := int32(2)
-	deployment.Spec.Replicas = &replicaCount
-	deployments := []v1.Deployment{
-		deployment,
-	}
-	assert.Equal(t, int32(2), getJobManagerCount(deployments, &app))
-}
-
 func TestJobManagerCreateSuccess(t *testing.T) {
 	testController := getJMControllerForTest()
 	app := getFlinkTestApp()

--- a/pkg/controller/flink/task_manager_controller.go
+++ b/pkg/controller/flink/task_manager_controller.go
@@ -90,19 +90,6 @@ func (t *TaskManagerController) CreateIfNotExist(ctx context.Context, applicatio
 	return false, nil
 }
 
-func getTaskManagerDeployment(deployments []v1.Deployment, application *v1alpha1.FlinkApplication) *v1.Deployment {
-	tmDeploymentName := getTaskManagerName(application, HashForApplication(application))
-	return k8.GetDeploymentWithName(deployments, tmDeploymentName)
-}
-
-func getTaskManagerCount(deployments []v1.Deployment, application *v1alpha1.FlinkApplication) int32 {
-	taskManagerDeployment := getTaskManagerDeployment(deployments, application)
-	if taskManagerDeployment == nil {
-		return 0
-	}
-	return *taskManagerDeployment.Spec.Replicas
-}
-
 func GetTaskManagerPorts(app *v1alpha1.FlinkApplication) []coreV1.ContainerPort {
 	return []coreV1.ContainerPort{
 		{

--- a/pkg/controller/flink/task_manager_controller_test.go
+++ b/pkg/controller/flink/task_manager_controller_test.go
@@ -49,28 +49,6 @@ func TestGetTaskManagerPodName(t *testing.T) {
 	assert.Equal(t, "app-name-"+testAppHash+"-tm-pod", getTaskManagerPodName(&app, testAppHash))
 }
 
-func TestGetTaskManagerDeployment(t *testing.T) {
-	app := getFlinkTestApp()
-	deployment := v1.Deployment{}
-	deployment.Name = getTaskManagerName(&app, testAppHash)
-	deployments := []v1.Deployment{
-		deployment,
-	}
-	assert.Equal(t, deployment, *getTaskManagerDeployment(deployments, &app))
-}
-
-func TestGetTaskManagerReplicaCount(t *testing.T) {
-	app := getFlinkTestApp()
-	deployment := v1.Deployment{}
-	deployment.Name = getTaskManagerName(&app, testAppHash)
-	replicaCount := int32(2)
-	deployment.Spec.Replicas = &replicaCount
-	deployments := []v1.Deployment{
-		deployment,
-	}
-	assert.Equal(t, int32(2), getTaskManagerCount(deployments, &app))
-}
-
 func TestTaskManagerCreateSuccess(t *testing.T) {
 	testController := getTMControllerForTest()
 	app := getFlinkTestApp()


### PR DESCRIPTION
We somehow ended up with two codepaths for finding the current deployments associated with an application. The one used by the status checks was using the current application hash, not the DeployHash, to find the deployments.. This caused it to fail for applications that had been rolled back with error logs like

```
ERRO[0000] Unable to find task manager deployment        app_name=operator-test-app ns=default phase=DeployFailed src="flink.go:461"
```

This PR removes that function and moves the callers to `GetCurrentDeploymentsForApp`, which also has the benefit of making the handling code a bit simpler.