### PR TITLE
[STRMCMP-558] Event improvements

### DIFF
--- a/pkg/controller/flink/flink.go
+++ b/pkg/controller/flink/flink.go
@@ -82,7 +82,7 @@ type ControllerInterface interface {
 	FindExternalizedCheckpoint(ctx context.Context, application *v1alpha1.FlinkApplication, hash string) (string, error)
 
 	// Logs an event to the FlinkApplication resource and to the operator log
-	LogEvent(ctx context.Context, app *v1alpha1.FlinkApplication, eventType string, message string)
+	LogEvent(ctx context.Context, app *v1alpha1.FlinkApplication, eventType string, reason string, message string)
 
 	// Compares and updates new cluster status with current cluster status
 	// Returns true if there is a change in ClusterStatus
@@ -206,7 +206,7 @@ func (f *Controller) CreateCluster(ctx context.Context, application *v1alpha1.Fl
 	newlyCreatedJm, err := f.jobManager.CreateIfNotExist(ctx, application)
 	if err != nil {
 		logger.Errorf(ctx, "Job manager cluster creation did not succeed %v", err)
-		f.LogEvent(ctx, application, corev1.EventTypeWarning,
+		f.LogEvent(ctx, application, corev1.EventTypeWarning, "CreateClusterFailed",
 			fmt.Sprintf("Failed to create job managers for deploy %s: %v",
 				HashForApplication(application), err))
 
@@ -215,14 +215,14 @@ func (f *Controller) CreateCluster(ctx context.Context, application *v1alpha1.Fl
 	newlyCreatedTm, err := f.taskManager.CreateIfNotExist(ctx, application)
 	if err != nil {
 		logger.Errorf(ctx, "Task manager cluster creation did not succeed %v", err)
-		f.LogEvent(ctx, application, corev1.EventTypeWarning,
+		f.LogEvent(ctx, application, corev1.EventTypeWarning, "CreateClusterFailed",
 			fmt.Sprintf("Failed to create task managers for deploy %s: %v",
 				HashForApplication(application), err))
 		return err
 	}
 
 	if newlyCreatedJm || newlyCreatedTm {
-		f.LogEvent(ctx, application, corev1.EventTypeNormal,
+		f.LogEvent(ctx, application, corev1.EventTypeNormal, "CreatingCluster",
 			fmt.Sprintf("Creating Flink cluster for deploy %s", HashForApplication(application)))
 	}
 	return nil
@@ -391,7 +391,8 @@ func (f *Controller) DeleteOldResourcesForApp(ctx context.Context, app *v1alpha1
 	}
 
 	for k := range deletedHashes {
-		f.LogEvent(ctx, app, corev1.EventTypeNormal, fmt.Sprintf("Deleted old cluster with hash %s", k))
+		f.LogEvent(ctx, app, corev1.EventTypeNormal, "ToreDownCluster",
+			fmt.Sprintf("Deleted old cluster with hash %s", k))
 	}
 
 	return nil
@@ -414,16 +415,7 @@ func (f *Controller) FindExternalizedCheckpoint(ctx context.Context, application
 	return checkpoint.ExternalPath, nil
 }
 
-func (f *Controller) LogEvent(ctx context.Context, app *v1alpha1.FlinkApplication, eventType string, message string) {
-	reason := "Create"
-	if app.Status.DeployHash != "" {
-		// this is not the first deploy
-		reason = "Update"
-	}
-	if app.DeletionTimestamp != nil {
-		reason = "Delete"
-	}
-
+func (f *Controller) LogEvent(ctx context.Context, app *v1alpha1.FlinkApplication, eventType string, reason string, message string) {
 	f.eventRecorder.Event(app, eventType, reason, message)
 	logger.Infof(ctx, "Logged %s event: %s: %s", eventType, reason, message)
 }

--- a/pkg/controller/flink/flink.go
+++ b/pkg/controller/flink/flink.go
@@ -207,7 +207,8 @@ func (f *Controller) CreateCluster(ctx context.Context, application *v1alpha1.Fl
 	if err != nil {
 		logger.Errorf(ctx, "Job manager cluster creation did not succeed %v", err)
 		f.LogEvent(ctx, application, corev1.EventTypeWarning,
-			fmt.Sprintf("Failed to create job managers: %v", err))
+			fmt.Sprintf("Failed to create job managers for deploy %s: %v",
+				HashForApplication(application), err))
 
 		return err
 	}
@@ -215,12 +216,14 @@ func (f *Controller) CreateCluster(ctx context.Context, application *v1alpha1.Fl
 	if err != nil {
 		logger.Errorf(ctx, "Task manager cluster creation did not succeed %v", err)
 		f.LogEvent(ctx, application, corev1.EventTypeWarning,
-			fmt.Sprintf("Failed to create task managers: %v", err))
+			fmt.Sprintf("Failed to create task managers for deploy %s: %v",
+				HashForApplication(application), err))
 		return err
 	}
 
 	if newlyCreatedJm || newlyCreatedTm {
-		f.LogEvent(ctx, application, corev1.EventTypeNormal, "Flink cluster created")
+		f.LogEvent(ctx, application, corev1.EventTypeNormal,
+			fmt.Sprintf("Creating Flink cluster for deploy %s", HashForApplication(application)))
 	}
 	return nil
 }

--- a/pkg/controller/flink/mock/mock_flink.go
+++ b/pkg/controller/flink/mock/mock_flink.go
@@ -119,7 +119,7 @@ func (m *FlinkController) FindExternalizedCheckpoint(ctx context.Context, applic
 	return "", nil
 }
 
-func (m *FlinkController) LogEvent(ctx context.Context, app *v1alpha1.FlinkApplication, eventType string, message string) {
+func (m *FlinkController) LogEvent(ctx context.Context, app *v1alpha1.FlinkApplication, eventType string, reason string, message string) {
 	m.Events = append(m.Events, corev1.Event{
 		InvolvedObject: corev1.ObjectReference{
 			Kind:      app.Kind,
@@ -127,7 +127,7 @@ func (m *FlinkController) LogEvent(ctx context.Context, app *v1alpha1.FlinkAppli
 			Namespace: app.Namespace,
 		},
 		Type:    eventType,
-		Reason:  "Test",
+		Reason:  reason,
 		Message: message,
 	})
 }


### PR DESCRIPTION
This PR makes two improvements to the events that the operator emits for FlinkApplication resources.

First, it ensures that all deploy-related events are unique to a particular deploy (generally by including the hash of the resource in the message). This ensures that if two deploys occur in rapid succession, the second one will still produce events (if more than 10 events with the same message are emitted within a 10 minute period, later events are dropped). This prevents a situation where a developer does a deploy, encounters an error that produces several events, tries the deploy again but this time doesn't seen any events because we have already exhausted our limit.

The second change is to fix the reason field of the events we emit. When I originally added events I misunderstood what the reason field was. Re-reading the docs, I now understand it to be basically a machine-readable code for the event, with the message as its human-readable counterpart:

> 'reason' is the reason this event is generated. 'reason' should be short and unique; it should be in UpperCamelCase format (starting with a capital letter). "reason" will be used to automate handling of events, so imagine people writing switch statements to handle them. You want to make that easy.

Using unique reasons for each event also prevents distinct events from being improperly combined.