### PR TITLE
[Backward Incompatible] Add env variables for Flink managers and fix for JM HA

### DIFF
--- a/examples/wordcount/Dockerfile
+++ b/examples/wordcount/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH=$FLINK_HOME/bin:$HADOOP_HOME/bin:$MAVEN_HOME/bin:$PATH
 COPY . /code
 
 # Configure Flink version
-ENV FLINK_VERSION=1.8.0 \
+ENV FLINK_VERSION=1.8.1 \
     HADOOP_SCALA_VARIANT=scala_2.12
 
 # Install dependencies

--- a/integ/README.md
+++ b/integ/README.md
@@ -23,8 +23,8 @@ By default the tests create, use, and clean up the namespace
 These tests use a sample Flink job [operator-test-app](/integ/operator-test-app/). The
 tests currently use two images built from here:
 
-* `lyft/operator-test-app:6c45caca225489895cb1353dae25069b5d43746f.1`
-* `lyft/operator-test-app:6c45caca225489895cb1353dae25069b5d43746f.2`
+* `lyft/operator-test-app:5bb866f79bb8cd41633f46307040065ed21531be.1`
+* `lyft/operator-test-app:5bb866f79bb8cd41633f46307040065ed21531be.2`
 
 Those images are available on our private Dockerhub registry, and you
 will either need to pull them locally or give Kubernetes access to the

--- a/integ/README.md
+++ b/integ/README.md
@@ -23,8 +23,8 @@ By default the tests create, use, and clean up the namespace
 These tests use a sample Flink job [operator-test-app](/integ/operator-test-app/). The
 tests currently use two images built from here:
 
-* `lyft/operator-test-app:ddbf570fe838205040c226807b0285a326a7d4c3.1`
-* `lyft/operator-test-app:ddbf570fe838205040c226807b0285a326a7d4c3.2`
+* `lyft/operator-test-app:b1b3cb8e8f98bd41f44f9c89f8462ce255e0d13f.1`
+* `lyft/operator-test-app:b1b3cb8e8f98bd41f44f9c89f8462ce255e0d13f.2`
 
 Those images are available on our private Dockerhub registry, and you
 will either need to pull them locally or give Kubernetes access to the

--- a/integ/README.md
+++ b/integ/README.md
@@ -23,8 +23,8 @@ By default the tests create, use, and clean up the namespace
 These tests use a sample Flink job [operator-test-app](/integ/operator-test-app/). The
 tests currently use two images built from here:
 
-* `lyft/operator-test-app:5bb866f79bb8cd41633f46307040065ed21531be.1`
-* `lyft/operator-test-app:5bb866f79bb8cd41633f46307040065ed21531be.2`
+* `lyft/operator-test-app:ddbf570fe838205040c226807b0285a326a7d4c3.1`
+* `lyft/operator-test-app:ddbf570fe838205040c226807b0285a326a7d4c3.2`
 
 Those images are available on our private Dockerhub registry, and you
 will either need to pull them locally or give Kubernetes access to the

--- a/integ/operator-test-app/Dockerfile
+++ b/integ/operator-test-app/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH=$FLINK_HOME/bin:$HADOOP_HOME/bin:$MAVEN_HOME/bin:$PATH
 COPY . /code
 
 # Configure Flink version
-ENV FLINK_VERSION=1.8.0 \
+ENV FLINK_VERSION=1.8.1 \
     HADOOP_SCALA_VARIANT=scala_2.12
 
 # Install dependencies

--- a/integ/operator-test-app/docker-entrypoint.sh
+++ b/integ/operator-test-app/docker-entrypoint.sh
@@ -15,7 +15,7 @@ drop_privs_cmd() {
 
 # Add in extra configs set by the operator
 if [ -n "$OPERATOR_FLINK_CONFIG" ]; then
-    echo "$OPERATOR_FLINK_CONFIG" >> "$FLINK_HOME/conf/flink-conf.yaml"
+    echo "$OPERATOR_FLINK_CONFIG" >> "/usr/local/flink-conf.yaml"
 fi
 
 envsubst < /usr/local/flink-conf.yaml > $FLINK_HOME/conf/flink-conf.yaml

--- a/integ/operator-test-app/docker-entrypoint.sh
+++ b/integ/operator-test-app/docker-entrypoint.sh
@@ -13,22 +13,12 @@ drop_privs_cmd() {
     fi
 }
 
-envsubst < /usr/local/flink-conf.yaml > $FLINK_HOME/conf/flink-conf.yaml
-
-if [ "$FLINK_DEPLOYMENT_TYPE" = "jobmanager" ]; then
-    echo "jobmanager.rpc.address: $HOST_NAME" >> "$FLINK_HOME/conf/flink-conf.yaml"
-fi
-
-# As the taskmanager pods are accessible only by (cluster) ip address,
-# we must manually configure this based on the podIp kubernetes
-if [ "$FLINK_DEPLOYMENT_TYPE" = "taskmanager" ]; then
-    echo "taskmanager.host: $HOST_IP" >> "$FLINK_HOME/conf/flink-conf.yaml"
-fi
-
 # Add in extra configs set by the operator
 if [ -n "$OPERATOR_FLINK_CONFIG" ]; then
     echo "$OPERATOR_FLINK_CONFIG" >> "$FLINK_HOME/conf/flink-conf.yaml"
 fi
+
+envsubst < /usr/local/flink-conf.yaml > $FLINK_HOME/conf/flink-conf.yaml
 
 COMMAND=$@
 

--- a/integ/operator-test-app/docker-entrypoint.sh
+++ b/integ/operator-test-app/docker-entrypoint.sh
@@ -15,12 +15,14 @@ drop_privs_cmd() {
 
 envsubst < /usr/local/flink-conf.yaml > $FLINK_HOME/conf/flink-conf.yaml
 
+if [ "$FLINK_DEPLOYMENT_TYPE" = "jobmanager" ]; then
+    echo "jobmanager.rpc.address: $HOST_NAME" >> "$FLINK_HOME/conf/flink-conf.yaml"
+fi
+
 # As the taskmanager pods are accessible only by (cluster) ip address,
 # we must manually configure this based on the podIp kubernetes
-# variable, which is assigned to TASKMANAGER_HOSTNAME env var by the
-# operator.
-if [ -n "$TASKMANAGER_HOSTNAME" ]; then
-    echo "taskmanager.host: $TASKMANAGER_HOSTNAME" >> "$FLINK_HOME/conf/flink-conf.yaml"
+if [ "$FLINK_DEPLOYMENT_TYPE" = "taskmanager" ]; then
+    echo "taskmanager.host: $HOST_IP" >> "$FLINK_HOME/conf/flink-conf.yaml"
 fi
 
 # Add in extra configs set by the operator
@@ -37,11 +39,11 @@ fi
 if [ "$COMMAND" = "help" ]; then
     echo "Usage: $(basename "$0") (jobmanager|taskmanager|local|help)"
     exit 0
-elif [ "$COMMAND" = "jobmanager" ]; then
+elif [ "$FLINK_DEPLOYMENT_TYPE" = "jobmanager" ]; then
     echo "Starting Job Manager"
     echo "config file: " && grep '^[^\n#]' "$FLINK_HOME/conf/flink-conf.yaml"
     exec $(drop_privs_cmd) "$FLINK_HOME/bin/jobmanager.sh" start-foreground
-elif [ "$COMMAND" = "taskmanager" ]; then
+elif [ "$FLINK_DEPLOYMENT_TYPE" = "taskmanager" ]; then
     echo "Starting Task Manager"
     echo "config file: " && grep '^[^\n#]' "$FLINK_HOME/conf/flink-conf.yaml"
     exec $(drop_privs_cmd) "$FLINK_HOME/bin/taskmanager.sh" start-foreground

--- a/integ/simple_test.go
+++ b/integ/simple_test.go
@@ -15,7 +15,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const NewImage = "lyft/operator-test-app:ddbf570fe838205040c226807b0285a326a7d4c3.2"
+const NewImage = "lyft/operator-test-app:b1b3cb8e8f98bd41f44f9c89f8462ce255e0d13f.2"
 
 func updateAndValidate(c *C, s *IntegSuite, name string, updateFn func(app *v1alpha1.FlinkApplication), failurePhase v1alpha1.FlinkApplicationPhase) *v1alpha1.FlinkApplication {
 	app, err := s.Util.GetFlinkApplication(name)

--- a/integ/simple_test.go
+++ b/integ/simple_test.go
@@ -15,7 +15,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const NewImage = "lyft/operator-test-app:6c45caca225489895cb1353dae25069b5d43746f.2"
+const NewImage = "lyft/operator-test-app:ddbf570fe838205040c226807b0285a326a7d4c3.2"
 
 func updateAndValidate(c *C, s *IntegSuite, name string, updateFn func(app *v1alpha1.FlinkApplication), failurePhase v1alpha1.FlinkApplicationPhase) *v1alpha1.FlinkApplication {
 	app, err := s.Util.GetFlinkApplication(name)

--- a/integ/test_app.yaml
+++ b/integ/test_app.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     environment: development
 spec:
-  image: lyft/operator-test-app:5bb866f79bb8cd41633f46307040065ed21531be.1
+  image: lyft/operator-test-app:ddbf570fe838205040c226807b0285a326a7d4c3.1
   imagePullSecrets:
     - name: dockerhub
   flinkConfig:

--- a/integ/test_app.yaml
+++ b/integ/test_app.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     environment: development
 spec:
-  image: lyft/operator-test-app:6c45caca225489895cb1353dae25069b5d43746f.1
+  image: lyft/operator-test-app:5bb866f79bb8cd41633f46307040065ed21531be.1
   imagePullSecrets:
     - name: dockerhub
   flinkConfig:

--- a/integ/test_app.yaml
+++ b/integ/test_app.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     environment: development
 spec:
-  image: lyft/operator-test-app:ddbf570fe838205040c226807b0285a326a7d4c3.1
+  image: lyft/operator-test-app:b1b3cb8e8f98bd41f44f9c89f8462ce255e0d13f.1
   imagePullSecrets:
     - name: dockerhub
   flinkConfig:

--- a/pkg/controller/flink/config.go
+++ b/pkg/controller/flink/config.go
@@ -1,6 +1,8 @@
 package flink
 
 import (
+	"strings"
+
 	"github.com/lyft/flinkk8soperator/pkg/apis/app/v1alpha1"
 	"gopkg.in/yaml.v2"
 )
@@ -14,6 +16,7 @@ const (
 	UIDefaultPort                 = 8081
 	MetricsQueryDefaultPort       = 50101
 	OffHeapMemoryDefaultFraction  = 0.5
+	HighAvailabilityKey           = "high-availability"
 )
 
 func firstNonNil(x *int32, y int32) int32 {
@@ -117,4 +120,14 @@ func renderFlinkConfig(app *v1alpha1.FlinkApplication) (string, error) {
 		return "", err
 	}
 	return string(b), nil
+}
+
+func isHAEnabled(flinkConfig v1alpha1.FlinkConfig) bool {
+	if val, ok := flinkConfig[HighAvailabilityKey]; ok {
+		value := val.(string)
+		if strings.ToLower(strings.TrimSpace(value)) != "none" {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/controller/flink/container_utils.go
+++ b/pkg/controller/flink/container_utils.go
@@ -180,11 +180,13 @@ func InjectOperatorCustomizedConfig(deployment *appsv1.Deployment, app *v1alpha1
 		var newEnv []v1.EnvVar
 		for _, env := range container.Env {
 			if env.Name == OperatorFlinkConfig {
-				env.Value = fmt.Sprintf("%s\nhigh-availability.cluster-id: %s-%s\n", env.Value, app.Name, hash)
-				if getJobmanagerReplicas(app) == 1 {
-					env.Value = fmt.Sprintf("%sjobmanager.rpc.address: %s\n", env.Value, VersionedJobManagerServiceName(app, hash))
-				} else if deploymentType == FlinkDeploymentTypeJobmanager {
-					env.Value = fmt.Sprintf("%sjobmanager.rpc.address: $HOST_IP\n", env.Value)
+				if isHAEnabled(app.Spec.FlinkConfig) {
+					env.Value = fmt.Sprintf("%s\nhigh-availability.cluster-id: %s-%s\n", env.Value, app.Name, hash)
+					if deploymentType == FlinkDeploymentTypeJobmanager {
+						env.Value = fmt.Sprintf("%sjobmanager.rpc.address: $HOST_IP\n", env.Value)
+					}
+				} else {
+					env.Value = fmt.Sprintf("%s\njobmanager.rpc.address: %s\n", env.Value, VersionedJobManagerServiceName(app, hash))
 				}
 				if deploymentType == FlinkDeploymentTypeTaskmanager {
 					env.Value = fmt.Sprintf("%staskmanager.host: $HOST_IP\n", env.Value)

--- a/pkg/controller/flink/container_utils.go
+++ b/pkg/controller/flink/container_utils.go
@@ -24,8 +24,8 @@ const (
 	AwsMetadataServiceTimeout        = "5"
 	AwsMetadataServiceNumAttempts    = "20"
 	OperatorFlinkConfig              = "OPERATOR_FLINK_CONFIG"
-	hostName                         = "HOST_NAME"
-	hostIP                           = "HOST_IP"
+	HostName                         = "HOST_NAME"
+	HostIP                           = "HOST_IP"
 	FlinkDeploymentTypeEnv           = "FLINK_DEPLOYMENT_TYPE"
 	FlinkDeploymentType              = "flink-deployment-type"
 	FlinkDeploymentTypeJobmanager    = "jobmanager"
@@ -91,7 +91,7 @@ func getFlinkEnv(app *v1alpha1.FlinkApplication) ([]v1.EnvVar, error) {
 			Value: flinkConfig,
 		},
 		{
-			Name: hostName,
+			Name: HostName,
 			ValueFrom: &v1.EnvVarSource{
 				FieldRef: &v1.ObjectFieldSelector{
 					FieldPath: "metadata.name",
@@ -99,7 +99,7 @@ func getFlinkEnv(app *v1alpha1.FlinkApplication) ([]v1.EnvVar, error) {
 			},
 		},
 		{
-			Name: hostIP,
+			Name: HostIP,
 			ValueFrom: &v1.EnvVarSource{
 				FieldRef: &v1.ObjectFieldSelector{
 					FieldPath: "status.podIP",

--- a/pkg/controller/flink/container_utils.go
+++ b/pkg/controller/flink/container_utils.go
@@ -25,7 +25,7 @@ const (
 	AwsMetadataServiceNumAttempts    = "20"
 	OperatorFlinkConfig              = "OPERATOR_FLINK_CONFIG"
 	hostName                         = "HOST_NAME"
-	hostIp                           = "HOST_IP"
+	hostIP                           = "HOST_IP"
 	FlinkDeploymentTypeEnv           = "FLINK_DEPLOYMENT_TYPE"
 	FlinkDeploymentType              = "flink-deployment-type"
 	FlinkDeploymentTypeJobmanager    = "jobmanager"
@@ -99,7 +99,7 @@ func getFlinkEnv(app *v1alpha1.FlinkApplication) ([]v1.EnvVar, error) {
 			},
 		},
 		{
-			Name: hostIp,
+			Name: hostIP,
 			ValueFrom: &v1.EnvVarSource{
 				FieldRef: &v1.ObjectFieldSelector{
 					FieldPath: "status.podIP",
@@ -174,15 +174,19 @@ func HashForApplication(app *v1alpha1.FlinkApplication) string {
 	return fmt.Sprintf("%08x", hasher.Sum32())
 }
 
-func InjectHashesIntoConfig(deployment *appsv1.Deployment, app *v1alpha1.FlinkApplication, hash string, deploymentType string) {
+func InjectOperatorCustomizedConfig(deployment *appsv1.Deployment, app *v1alpha1.FlinkApplication, hash string, deploymentType string) {
 	var newContainers []v1.Container
 	for _, container := range deployment.Spec.Template.Spec.Containers {
 		var newEnv []v1.EnvVar
 		for _, env := range container.Env {
 			if env.Name == OperatorFlinkConfig {
 				env.Value = fmt.Sprintf("%s\nhigh-availability.cluster-id: %s-%s\n", env.Value, app.Name, hash)
+				if deploymentType == FlinkDeploymentTypeJobmanager {
+					env.Value = fmt.Sprintf("%sjobmanager.rpc.address: $HOST_NAME\n", env.Value)
+				}
 				if deploymentType == FlinkDeploymentTypeTaskmanager {
 					env.Value = fmt.Sprintf("%sjobmanager.rpc.address: %s\n", env.Value, VersionedJobManagerServiceName(app, hash))
+					env.Value = fmt.Sprintf("%staskmanager.host: $HOST_IP\n", env.Value)
 				}
 			}
 			newEnv = append(newEnv, env)

--- a/pkg/controller/flink/container_utils.go
+++ b/pkg/controller/flink/container_utils.go
@@ -181,11 +181,12 @@ func InjectOperatorCustomizedConfig(deployment *appsv1.Deployment, app *v1alpha1
 		for _, env := range container.Env {
 			if env.Name == OperatorFlinkConfig {
 				env.Value = fmt.Sprintf("%s\nhigh-availability.cluster-id: %s-%s\n", env.Value, app.Name, hash)
-				if deploymentType == FlinkDeploymentTypeJobmanager {
-					env.Value = fmt.Sprintf("%sjobmanager.rpc.address: $HOST_NAME\n", env.Value)
+				if getJobmanagerReplicas(app) == 1 {
+					env.Value = fmt.Sprintf("%sjobmanager.rpc.address: %s\n", env.Value, VersionedJobManagerServiceName(app, hash))
+				} else if deploymentType == FlinkDeploymentTypeJobmanager {
+					env.Value = fmt.Sprintf("%sjobmanager.rpc.address: $HOST_IP\n", env.Value)
 				}
 				if deploymentType == FlinkDeploymentTypeTaskmanager {
-					env.Value = fmt.Sprintf("%sjobmanager.rpc.address: %s\n", env.Value, VersionedJobManagerServiceName(app, hash))
 					env.Value = fmt.Sprintf("%staskmanager.host: $HOST_IP\n", env.Value)
 				}
 			}

--- a/pkg/controller/flink/flink_test.go
+++ b/pkg/controller/flink/flink_test.go
@@ -29,7 +29,7 @@ import (
 const testImage = "123.xyz.com/xx:11ae1218924428faabd9b64423fa0c332efba6b2"
 
 // Note: if you find yourself changing this to fix a test, that should be treated as a breaking API change
-const testAppHash = "0de896bc"
+const testAppHash = "de844839"
 const testAppName = "app-name"
 const testNamespace = "ns"
 const testJobID = "j1"

--- a/pkg/controller/flink/flink_test.go
+++ b/pkg/controller/flink/flink_test.go
@@ -29,7 +29,7 @@ import (
 const testImage = "123.xyz.com/xx:11ae1218924428faabd9b64423fa0c332efba6b2"
 
 // Note: if you find yourself changing this to fix a test, that should be treated as a breaking API change
-const testAppHash = "cb56c9a1"
+const testAppHash = "0de896bc"
 const testAppName = "app-name"
 const testNamespace = "ns"
 const testJobID = "j1"

--- a/pkg/controller/flink/job_manager_controller.go
+++ b/pkg/controller/flink/job_manager_controller.go
@@ -248,7 +248,7 @@ func FetchJobManagerContainerObj(application *v1alpha1.FlinkApplication) *coreV1
 	ports := getJobManagerPorts(application)
 	operatorEnv := GetFlinkContainerEnv(application)
 	operatorEnv = append(operatorEnv, coreV1.EnvVar{
-		Name: FlinkDeploymentTypeEnv,
+		Name:  FlinkDeploymentTypeEnv,
 		Value: FlinkDeploymentTypeJobmanager,
 	})
 	operatorEnv = append(operatorEnv, jmConfig.Environment.Env...)
@@ -346,7 +346,7 @@ func FetchJobMangerDeploymentCreateObj(app *v1alpha1.FlinkApplication, hash stri
 	template.Spec.Selector.MatchLabels[FlinkAppHash] = hash
 	template.Spec.Template.Name = getJobManagerPodName(app, hash)
 
-	InjectHashesIntoConfig(template, app, hash)
+	InjectOperatorCustomizedConfig(template, app, hash, FlinkDeploymentTypeJobmanager)
 
 	return template
 }

--- a/pkg/controller/flink/job_manager_controller.go
+++ b/pkg/controller/flink/job_manager_controller.go
@@ -247,6 +247,10 @@ func FetchJobManagerContainerObj(application *v1alpha1.FlinkApplication) *coreV1
 
 	ports := getJobManagerPorts(application)
 	operatorEnv := GetFlinkContainerEnv(application)
+	operatorEnv = append(operatorEnv, coreV1.EnvVar{
+		Name: FlinkDeploymentTypeEnv,
+		Value: FlinkDeploymentTypeJobmanager,
+	})
 	operatorEnv = append(operatorEnv, jmConfig.Environment.Env...)
 
 	return &coreV1.Container{

--- a/pkg/controller/flink/job_manager_controller.go
+++ b/pkg/controller/flink/job_manager_controller.go
@@ -24,7 +24,7 @@ const (
 	JobManagerPodNameFormat             = "%s-%s-jm-pod"
 	JobManagerContainerName             = "jobmanager"
 	JobManagerArg                       = "jobmanager"
-	JobManagerReadinessPath             = "/config"
+	JobManagerReadinessPath             = "/overview"
 	JobManagerReadinessInitialDelaySec  = 10
 	JobManagerReadinessTimeoutSec       = 1
 	JobManagerReadinessSuccessThreshold = 1

--- a/pkg/controller/flink/job_manager_controller_test.go
+++ b/pkg/controller/flink/job_manager_controller_test.go
@@ -51,7 +51,7 @@ func TestJobManagerCreateSuccess(t *testing.T) {
 		"flink-job-properties": "jarName: test.jar\nparallelism: 8\nentryClass:com.test.MainClass\nprogramArgs:\"--test\"",
 	}
 	app.Annotations = annotations
-	hash := "0b1b39e8"
+	hash := "390e4c6d"
 	expectedLabels := map[string]string{
 		"flink-app":             "app-name",
 		"flink-app-hash":        hash,
@@ -82,7 +82,7 @@ func TestJobManagerCreateSuccess(t *testing.T) {
 				"query.server.port: 6124\ntaskmanager.heap.size: 512\n"+
 				"taskmanager.numberOfTaskSlots: 16\n\n"+
 				"high-availability.cluster-id: app-name-"+hash+"\n"+
-				"jobmanager.rpc.address: $HOST_NAME\n",
+				"jobmanager.rpc.address: app-name-"+hash+"\n",
 				common.GetEnvVar(deployment.Spec.Template.Spec.Containers[0].Env,
 					"OPERATOR_FLINK_CONFIG").Value)
 		case 2:

--- a/pkg/controller/flink/job_manager_controller_test.go
+++ b/pkg/controller/flink/job_manager_controller_test.go
@@ -51,7 +51,7 @@ func TestJobManagerCreateSuccess(t *testing.T) {
 		"flink-job-properties": "jarName: test.jar\nparallelism: 8\nentryClass:com.test.MainClass\nprogramArgs:\"--test\"",
 	}
 	app.Annotations = annotations
-	hash := "334c7c5d"
+	hash := "0b1b39e8"
 	expectedLabels := map[string]string{
 		"flink-app":             "app-name",
 		"flink-app-hash":        hash,
@@ -82,7 +82,7 @@ func TestJobManagerCreateSuccess(t *testing.T) {
 				"query.server.port: 6124\ntaskmanager.heap.size: 512\n"+
 				"taskmanager.numberOfTaskSlots: 16\n\n"+
 				"high-availability.cluster-id: app-name-"+hash+"\n"+
-				"jobmanager.rpc.address: app-name-"+hash+"\n",
+				"jobmanager.rpc.address: $HOST_NAME\n",
 				common.GetEnvVar(deployment.Spec.Template.Spec.Containers[0].Env,
 					"OPERATOR_FLINK_CONFIG").Value)
 		case 2:

--- a/pkg/controller/flink/task_manager_controller.go
+++ b/pkg/controller/flink/task_manager_controller.go
@@ -121,18 +121,8 @@ func FetchTaskManagerContainerObj(application *v1alpha1.FlinkApplication) *coreV
 
 	operatorEnv := GetFlinkContainerEnv(application)
 	operatorEnv = append(operatorEnv, coreV1.EnvVar{
-		Name: FlinkDeploymentTypeEnv,
+		Name:  FlinkDeploymentTypeEnv,
 		Value: FlinkDeploymentTypeTaskmanager,
-	})
-
-	// TODO: To be removed, and use "HOST_IP" instead
-	operatorEnv = append(operatorEnv, coreV1.EnvVar{
-		Name: TaskManagerHostnameEnvVar,
-		ValueFrom: &coreV1.EnvVarSource{
-			FieldRef: &coreV1.ObjectFieldSelector{
-				FieldPath: "status.podIP",
-			},
-		},
 	})
 
 	operatorEnv = append(operatorEnv, tmConfig.Environment.Env...)
@@ -233,7 +223,7 @@ func FetchTaskMangerDeploymentCreateObj(app *v1alpha1.FlinkApplication, hash str
 	template.Spec.Selector.MatchLabels[FlinkAppHash] = hash
 	template.Spec.Template.Name = getTaskManagerPodName(app, hash)
 
-	InjectHashesIntoConfig(template, app, hash)
+	InjectOperatorCustomizedConfig(template, app, hash, FlinkDeploymentTypeTaskmanager)
 
 	return template
 }

--- a/pkg/controller/flink/task_manager_controller.go
+++ b/pkg/controller/flink/task_manager_controller.go
@@ -120,7 +120,12 @@ func FetchTaskManagerContainerObj(application *v1alpha1.FlinkApplication) *coreV
 	}
 
 	operatorEnv := GetFlinkContainerEnv(application)
+	operatorEnv = append(operatorEnv, coreV1.EnvVar{
+		Name: FlinkDeploymentTypeEnv,
+		Value: FlinkDeploymentTypeTaskmanager,
+	})
 
+	// TODO: To be removed, and use "HOST_IP" instead
 	operatorEnv = append(operatorEnv, coreV1.EnvVar{
 		Name: TaskManagerHostnameEnvVar,
 		ValueFrom: &coreV1.EnvVarSource{

--- a/pkg/controller/flink/task_manager_controller_test.go
+++ b/pkg/controller/flink/task_manager_controller_test.go
@@ -60,7 +60,7 @@ func TestTaskManagerCreateSuccess(t *testing.T) {
 		"flink-job-properties": "jarName: test.jar\nparallelism: 8\nentryClass:com.test.MainClass\nprogramArgs:\"--test\"",
 	}
 
-	hash := "0b1b39e8"
+	hash := "390e4c6d"
 
 	app.Annotations = annotations
 	expectedLabels := map[string]string{

--- a/pkg/controller/flink/task_manager_controller_test.go
+++ b/pkg/controller/flink/task_manager_controller_test.go
@@ -60,7 +60,7 @@ func TestTaskManagerCreateSuccess(t *testing.T) {
 		"flink-job-properties": "jarName: test.jar\nparallelism: 8\nentryClass:com.test.MainClass\nprogramArgs:\"--test\"",
 	}
 
-	hash := "334c7c5d"
+	hash := "0b1b39e8"
 
 	app.Annotations = annotations
 	expectedLabels := map[string]string{
@@ -85,7 +85,8 @@ func TestTaskManagerCreateSuccess(t *testing.T) {
 			"query.server.port: 6124\ntaskmanager.heap.size: 512\n"+
 			"taskmanager.numberOfTaskSlots: 16\n\n"+
 			"high-availability.cluster-id: app-name-"+hash+"\n"+
-			"jobmanager.rpc.address: app-name-"+hash+"\n",
+			"jobmanager.rpc.address: app-name-"+hash+"\n"+
+			"taskmanager.host: $HOST_IP\n",
 			common.GetEnvVar(deployment.Spec.Template.Spec.Containers[0].Env,
 				"OPERATOR_FLINK_CONFIG").Value)
 


### PR DESCRIPTION
We want the ability to assign some of the Flink config values dynamically based on values from host name, Ip, etc.

From an overall observation, currently both the operator and the image understands that jobmanager and task manager behave differently. In this particular context, we want the "jobmanager.rpc.address" to be pod name on the Job manager and service name on the task manager. 

I iterated across multiple options and arrived at this. Also update the Dockerfile in examples and test to reflect the same. The changes below can be simpler and all the responsibility of setting correct values can be delegated to the image. But I believe since operator is already ironing lots of things out and setting things correctly, I moved some of the logic to the operator. But I understand this is subjective and is up for discussion. Happy to take comments and change the logic.

cc @mwylde @glaksh100 