### PR TITLE
Add a ForceRollback option to CRD

### DIFF
--- a/docs/crd.md
+++ b/docs/crd.md
@@ -106,5 +106,7 @@ Below is the list of fields in the custom resource and their description
   * **VolumeMounts** `type:[]v1.VolumeMount`
     Describes a mounting of a Volume within a container.
     
-  * **CancelDeploy** `type:bool`
-    Can be set to true to force cancel a deploy/update. Resetting to false or un-setting implies the deploy will continue.
+  * **ForceRollback** `type:bool`
+    Can be set to true to force rollback a deploy/update. The rollback is **not** performed when the application is in a **RUNNING** phase.
+    If an application is successfully rolled back, it is moved to a *DeployFailed* phase. Un-setting or setting `ForceRollback` to `False` will allow updates to progress normally.
+    

--- a/docs/crd.md
+++ b/docs/crd.md
@@ -105,3 +105,6 @@ Below is the list of fields in the custom resource and their description
 
   * **VolumeMounts** `type:[]v1.VolumeMount`
     Describes a mounting of a Volume within a container.
+    
+  * **CancelDeploy** `type:bool`
+    Can be set to true to force cancel a deploy/update. Resetting to false or un-setting implies the deploy will continue.

--- a/integ/simple_test.go
+++ b/integ/simple_test.go
@@ -176,7 +176,6 @@ func (s *IntegSuite) TestSimple(c *C) {
 
 	{
 		newApp, err := s.Util.GetFlinkApplication(config.Name)
-		currHash := newApp.Status.DeployHash
 		c.Assert(err, IsNil)
 		// User sets large (bad) value for cluster update
 		var TaskManagerDefaultResources = corev1.ResourceRequirements{
@@ -206,7 +205,6 @@ func (s *IntegSuite) TestSimple(c *C) {
 
 		// but the job should still be running
 		c.Assert(newApp.Status.JobStatus.State, Equals, v1alpha1.Running)
-		c.Assert(newApp.Status.RollbackHash, Equals, currHash)
 		log.Info("Attempting to roll forward with fix")
 
 		// Fixing update

--- a/integ/simple_test.go
+++ b/integ/simple_test.go
@@ -205,7 +205,7 @@ func (s *IntegSuite) TestSimple(c *C) {
 
 		// but the job should still be running
 		c.Assert(newApp.Status.JobStatus.State, Equals, v1alpha1.Running)
-
+		c.Assert(newApp.Status.RollbackHash, Equals, newApp.Status.DeployHash)
 		log.Info("Attempting to roll forward with fix")
 
 		// Fixing update

--- a/integ/simple_test.go
+++ b/integ/simple_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	"os"
 	"time"
 
@@ -167,6 +169,60 @@ func (s *IntegSuite) TestSimple(c *C) {
 		updateAndValidate(c, s, config.Name, func(app *v1alpha1.FlinkApplication) {
 			app.Spec.JarName = config.Spec.JarName
 			app.Spec.RestartNonce = "rollback2"
+		}, "")
+	}
+
+	// Test cancelling a deploy
+
+	{
+		newApp, err := s.Util.GetFlinkApplication(config.Name)
+		c.Assert(err, IsNil)
+		// User sets large (bad) value for cluster update
+		var TaskManagerDefaultResources = corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("5Gi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("5Gi"),
+			},
+		}
+		newApp.Spec.TaskManagerConfig.Resources = &TaskManagerDefaultResources
+
+		_, _ = s.Util.FlinkApps().Update(newApp)
+		c.Assert(s.Util.WaitForPhase(newApp.Name, v1alpha1.FlinkApplicationClusterStarting, ""), IsNil)
+
+		// User realizes error and  cancels the deploy
+		log.Infof("Cancelling deploy...")
+		newApp.Spec.CancelDeploy = true
+		_, _ = s.Util.FlinkApps().Update(newApp)
+
+		// we should end up in the DeployFailed phase
+		c.Assert(s.Util.WaitForPhase(newApp.Name, v1alpha1.FlinkApplicationDeployFailed, ""), IsNil)
+		c.Assert(newApp.Spec.CancelDeploy, Equals, true)
+		log.Info("User cancelled deploy. Job is in deploy failed, waiting for tasks to start")
+
+		// but the job should still be running
+		c.Assert(newApp.Status.JobStatus.State, Equals, v1alpha1.Running)
+
+		log.Info("Attempting to roll forward with fix")
+
+		// Fixed resources
+		var TaskManagerFixedResources = corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("0.2"),
+				corev1.ResourceMemory: resource.MustParse("200Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("0.2"),
+				corev1.ResourceMemory: resource.MustParse("200Mi"),
+			},
+		}
+		// and we should be able to roll forward by resubmitting with a fixed config
+		updateAndValidate(c, s, config.Name, func(app *v1alpha1.FlinkApplication) {
+			app.Spec.TaskManagerConfig.Resources = &TaskManagerFixedResources
+			app.Spec.CancelDeploy = false
 		}, "")
 	}
 

--- a/integ/simple_test.go
+++ b/integ/simple_test.go
@@ -176,6 +176,7 @@ func (s *IntegSuite) TestSimple(c *C) {
 
 	{
 		newApp, err := s.Util.GetFlinkApplication(config.Name)
+		currHash := newApp.Status.DeployHash
 		c.Assert(err, IsNil)
 		// User sets large (bad) value for cluster update
 		var TaskManagerDefaultResources = corev1.ResourceRequirements{
@@ -205,7 +206,7 @@ func (s *IntegSuite) TestSimple(c *C) {
 
 		// but the job should still be running
 		c.Assert(newApp.Status.JobStatus.State, Equals, v1alpha1.Running)
-		c.Assert(newApp.Status.RollbackHash, Equals, newApp.Status.DeployHash)
+		c.Assert(newApp.Status.RollbackHash, Equals, currHash)
 		log.Info("Attempting to roll forward with fix")
 
 		// Fixing update

--- a/integ/simple_test.go
+++ b/integ/simple_test.go
@@ -201,7 +201,6 @@ func (s *IntegSuite) TestSimple(c *C) {
 		// we should end up in the DeployFailed phase
 		c.Assert(s.Util.WaitForPhase(newApp.Name, v1alpha1.FlinkApplicationDeployFailed, ""), IsNil)
 		c.Assert(newApp.Spec.ForceRollback, Equals, true)
-		c.Assert(newApp.Status.RollbackHash, Equals, newApp.Status.DeployHash)
 		log.Info("User cancelled deploy. Job is in deploy failed, waiting for tasks to start")
 
 		// but the job should still be running

--- a/integ/test.sh
+++ b/integ/test.sh
@@ -9,5 +9,5 @@ export OPERATOR_IMAGE=127.0.0.1:32000/flinkk8soperator:local
 umask 000
 
 cd $(dirname "$0")
-go test -timeout 20m -check.vv IntegSuite
+go test -timeout 22m -check.vv IntegSuite
 

--- a/pkg/apis/app/v1alpha1/types.go
+++ b/pkg/apis/app/v1alpha1/types.go
@@ -53,7 +53,7 @@ type FlinkApplicationSpec struct {
 	RestartNonce          string                       `json:"restartNonce"`
 	DeleteMode            DeleteMode                   `json:"deleteMode,omitempty"`
 	AllowNonRestoredState bool                         `json:"allowNonRestoredState,omitempty"`
-	CancelDeploy          bool                         `json:"cancelDeploy"`
+	ForceRollback         bool                         `json:"forceRollback"`
 }
 
 type FlinkConfig map[string]interface{}
@@ -163,6 +163,7 @@ type FlinkApplicationStatus struct {
 	ClusterStatus    FlinkClusterStatus            `json:"clusterStatus,omitempty"`
 	JobStatus        FlinkJobStatus                `json:"jobStatus"`
 	FailedDeployHash string                        `json:"failedDeployHash,omitEmpty"`
+	RollbackHash     string                        `json:"rollbackHash,omitEmpty"`
 	DeployHash       string                        `json:"deployHash"`
 	RetryCount       int32                         `json:"retryCount,omitEmpty"`
 	LastSeenError    *client.FlinkApplicationError `json:"lastSeenError,omitEmpty"`

--- a/pkg/apis/app/v1alpha1/types.go
+++ b/pkg/apis/app/v1alpha1/types.go
@@ -53,6 +53,7 @@ type FlinkApplicationSpec struct {
 	RestartNonce          string                       `json:"restartNonce"`
 	DeleteMode            DeleteMode                   `json:"deleteMode,omitempty"`
 	AllowNonRestoredState bool                         `json:"allowNonRestoredState,omitempty"`
+	CancelDeploy          bool                         `json:"cancelDeploy"`
 }
 
 type FlinkConfig map[string]interface{}

--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -78,7 +78,7 @@ func (s *FlinkStateMachine) updateApplicationPhase(application *v1alpha1.FlinkAp
 }
 
 func (s *FlinkStateMachine) shouldRollback(ctx context.Context, application *v1alpha1.FlinkApplication) bool {
-	if application.Spec.ForceRollback {
+	if application.Spec.ForceRollback && application.Status.Phase != v1alpha1.FlinkApplicationRollingBackJob {
 		return true
 	}
 	if application.Status.DeployHash == "" {

--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -80,6 +80,10 @@ func (s *FlinkStateMachine) updateApplicationPhase(ctx context.Context, applicat
 }
 
 func (s *FlinkStateMachine) shouldRollback(ctx context.Context, application *v1alpha1.FlinkApplication) bool {
+	if application.Spec.CancelDeploy {
+		//application.Spec.CancelDeploy = false
+		return true
+	}
 	if application.Status.DeployHash == "" {
 		// TODO: we may want some more sophisticated way of handling this case
 		// there's no previous deploy for this application, so nothing to roll back to

--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -231,7 +231,8 @@ func (s *FlinkStateMachine) deployFailed(ctx context.Context, app *v1alpha1.Flin
 	s.flinkController.LogEvent(ctx, app, corev1.EventTypeWarning, "RolledBackDeploy",
 		fmt.Sprintf("Successfull rolled back deploy %s", hash))
 	app.Status.FailedDeployHash = hash
-
+	// set rollbackHash to deployHash
+	app.Status.RollbackHash = app.Status.DeployHash
 	// Reset error and retry count
 	app.Status.LastSeenError = nil
 	app.Status.RetryCount = 0

--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -81,7 +81,6 @@ func (s *FlinkStateMachine) updateApplicationPhase(ctx context.Context, applicat
 
 func (s *FlinkStateMachine) shouldRollback(ctx context.Context, application *v1alpha1.FlinkApplication) bool {
 	if application.Spec.CancelDeploy {
-		//application.Spec.CancelDeploy = false
 		return true
 	}
 	if application.Status.DeployHash == "" {

--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -78,7 +78,7 @@ func (s *FlinkStateMachine) updateApplicationPhase(application *v1alpha1.FlinkAp
 }
 
 func (s *FlinkStateMachine) shouldRollback(ctx context.Context, application *v1alpha1.FlinkApplication) bool {
-	if application.Spec.CancelDeploy {
+	if application.Spec.ForceRollback {
 		return true
 	}
 	if application.Status.DeployHash == "" {
@@ -487,6 +487,8 @@ func (s *FlinkStateMachine) handleRollingBack(ctx context.Context, app *v1alpha1
 		app.Status.JobStatus.EntryClass, app.Status.JobStatus.ProgramArgs,
 		app.Status.JobStatus.AllowNonRestoredState)
 
+	// set rollbackHash
+	app.Status.RollbackHash = app.Status.DeployHash
 	if err != nil {
 		return applicationUnchanged, err
 	}

--- a/pkg/controller/flinkapplication/flink_state_machine_test.go
+++ b/pkg/controller/flinkapplication/flink_state_machine_test.go
@@ -1151,7 +1151,7 @@ func TestForceRollback(t *testing.T) {
 	stateMachineForTest := getTestStateMachine()
 	err := stateMachineForTest.Handle(context.Background(), &app)
 	assert.Nil(t, err)
-	// cancelled deploy while cluster is starting
+	// rolled deploy while cluster is starting
 	assert.Equal(t, v1alpha1.FlinkApplicationDeployFailed, app.Status.Phase)
 	assert.True(t, app.Spec.ForceRollback)
 }

--- a/pkg/controller/flinkapplication/flink_state_machine_test.go
+++ b/pkg/controller/flinkapplication/flink_state_machine_test.go
@@ -1129,18 +1129,18 @@ func TestErrorHandlingInRunningPhase(t *testing.T) {
 
 }
 
-func TestCancelDeploy(t *testing.T) {
+func TestForceRollback(t *testing.T) {
 	app := v1alpha1.FlinkApplication{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-app",
 			Namespace: "flink",
 		},
 		Spec: v1alpha1.FlinkApplicationSpec{
-			JarName:      "job.jar",
-			Parallelism:  5,
-			EntryClass:   "com.my.Class",
-			ProgramArgs:  "--test",
-			CancelDeploy: true,
+			JarName:       "job.jar",
+			Parallelism:   5,
+			EntryClass:    "com.my.Class",
+			ProgramArgs:   "--test",
+			ForceRollback: true,
 		},
 		Status: v1alpha1.FlinkApplicationStatus{
 			Phase:      v1alpha1.FlinkApplicationClusterStarting,
@@ -1153,5 +1153,5 @@ func TestCancelDeploy(t *testing.T) {
 	assert.Nil(t, err)
 	// cancelled deploy while cluster is starting
 	assert.Equal(t, v1alpha1.FlinkApplicationDeployFailed, app.Status.Phase)
-	assert.True(t, app.Spec.CancelDeploy)
+	assert.True(t, app.Spec.ForceRollback)
 }

--- a/pkg/controller/flinkapplication/flink_state_machine_test.go
+++ b/pkg/controller/flinkapplication/flink_state_machine_test.go
@@ -1130,6 +1130,7 @@ func TestErrorHandlingInRunningPhase(t *testing.T) {
 }
 
 func TestForceRollback(t *testing.T) {
+	oldHash := "old-hash-force-rollback"
 	app := v1alpha1.FlinkApplication{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-app",
@@ -1143,15 +1144,55 @@ func TestForceRollback(t *testing.T) {
 			ForceRollback: true,
 		},
 		Status: v1alpha1.FlinkApplicationStatus{
-			Phase:      v1alpha1.FlinkApplicationClusterStarting,
-			DeployHash: "old-hash-retry-err",
+			Phase:      v1alpha1.FlinkApplicationSubmittingJob,
+			DeployHash: oldHash,
 		},
 	}
 
 	stateMachineForTest := getTestStateMachine()
+	stateMachineForTest.clock.(*clock.FakeClock).SetTime(time.Now())
+
+	mockRetryHandler := stateMachineForTest.retryHandler.(*mock.RetryHandler)
+	mockRetryHandler.WaitOnErrorFunc = func(clock clock.Clock, lastUpdatedTime time.Time) (duration time.Duration, b bool) {
+		return time.Millisecond, true
+	}
+
+	mockK8Cluster := stateMachineForTest.k8Cluster.(*k8mock.K8Cluster)
+
+	getServiceCount := 0
+	mockK8Cluster.GetServiceFunc = func(ctx context.Context, namespace string, name string) (*v1.Service, error) {
+		hash := oldHash
+		if getServiceCount > 0 {
+			hash = oldHash
+		}
+
+		getServiceCount++
+		return &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "flink",
+			},
+			Spec: v1.ServiceSpec{
+				Selector: map[string]string{
+					"flink-app-hash": hash,
+				},
+			},
+		}, nil
+	}
+
+	mockFlinkController := stateMachineForTest.flinkController.(*mock.FlinkController)
+	mockFlinkController.IsServiceReadyFunc = func(ctx context.Context, application *v1alpha1.FlinkApplication, hash string) (bool, error) {
+		return true, nil
+	}
+
 	err := stateMachineForTest.Handle(context.Background(), &app)
 	assert.Nil(t, err)
 	// rolled deploy while cluster is starting
-	assert.Equal(t, v1alpha1.FlinkApplicationDeployFailed, app.Status.Phase)
+	assert.Equal(t, v1alpha1.FlinkApplicationRollingBackJob, app.Status.Phase)
 	assert.True(t, app.Spec.ForceRollback)
+
+	err = stateMachineForTest.Handle(context.Background(), &app)
+	// Check if rollback hash is set
+	assert.Nil(t, err)
+	assert.Equal(t, oldHash, app.Status.RollbackHash)
 }


### PR DESCRIPTION
This PR adds the ability for a user to cancel an ongoing deploy/update. This is done in the following way:
- By adding a `CancelDeploy` to the Spec. The user sets this to be True to cancel the deploy. 
- When `CancelDeploy` is set to True, `shouldRollback` evaluates to True and moves the application to a `DeployFailed` state. 
- Either un-setting or setting `CancelDeploy` to False enables the deploy to be continued (as would be the case when we fix forward from DeployFailed)
- An integration test case is added to `simple_test.sh` for this workflow.
- CRD doc is updated to include `CancelDeploy`

Alternatively, I could have added an extra state (like `DeployCancelled`) but felt that that would have been quite a bit of code duplication as it'd be very similar to the DeployFailed state. Happy to incorporate other ideas!