### PR TITLE
Change error update logic and fix retry bug

### DIFF
--- a/pkg/controller/flink/client/error_handler.go
+++ b/pkg/controller/flink/client/error_handler.go
@@ -146,5 +146,5 @@ func (r RetryHandler) GetRetryDelay(retryCount int32) time.Duration {
 }
 func (r RetryHandler) IsTimeToRetry(clock clock.Clock, lastUpdatedTime time.Time, retryCount int32) bool {
 	elapsedTime := clock.Since(lastUpdatedTime)
-	return elapsedTime <= r.GetRetryDelay(retryCount)
+	return elapsedTime >= r.GetRetryDelay(retryCount)
 }

--- a/pkg/controller/flink/client/error_handler_test.go
+++ b/pkg/controller/flink/client/error_handler_test.go
@@ -64,5 +64,6 @@ func TestRetryHandler_IsTimeToRetry(t *testing.T) {
 	olderTime := currTime.Add(-5 * time.Second)
 	fakeClock := clock.NewFakeClock(currTime.Time)
 	fakeClock.SetTime(time.Now())
-	assert.True(t, retryer.IsTimeToRetry(fakeClock, olderTime, 10))
+	// Set retry count to 0 to keep retry delay small
+	assert.True(t, retryer.IsTimeToRetry(fakeClock, olderTime, 0))
 }

--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -653,19 +653,21 @@ func (s *FlinkStateMachine) compareAndUpdateError(ctx context.Context, applicati
 		return
 	}
 
-	if flinkAppError, ok := err.(*client.FlinkApplicationError); ok {
-		application.Status.LastSeenError = flinkAppError
-	} else {
-		err = client.GetRetryableError(err, "UnknownMethod", client.GlobalFailure, client.DefaultRetries)
-		application.Status.LastSeenError = err.(*client.FlinkApplicationError)
-	}
+	if err != nil {
+		if flinkAppError, ok := err.(*client.FlinkApplicationError); ok {
+			application.Status.LastSeenError = flinkAppError
+		} else {
+			err = client.GetRetryableError(err, "UnknownMethod", client.GlobalFailure, client.DefaultRetries)
+			application.Status.LastSeenError = err.(*client.FlinkApplicationError)
+		}
 
-	now := v1.NewTime(s.clock.Now())
-	application.Status.LastSeenError.LastErrorUpdateTime = &now
+		now := v1.NewTime(s.clock.Now())
+		application.Status.LastSeenError.LastErrorUpdateTime = &now
 
-	updateErr := s.k8Cluster.UpdateK8Object(ctx, application)
-	if updateErr != nil {
-		logger.Errorf(ctx, "Updating last seen error failed with %v", updateErr)
+		updateErr := s.k8Cluster.UpdateK8Object(ctx, application)
+		if updateErr != nil {
+			logger.Errorf(ctx, "Updating last seen error failed with %v", updateErr)
+		}
 	}
 }
 

--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -143,6 +143,7 @@ func (s *FlinkStateMachine) handle(ctx context.Context, application *v1alpha1.Fl
 		logger.Infof(ctx, "Handling state %s for application", application.Status.Phase)
 	}
 	var appErr error
+	appPhase := application.Status.Phase
 	if s.IsTimeToHandlePhase(application) {
 		switch application.Status.Phase {
 		case v1alpha1.FlinkApplicationNew, v1alpha1.FlinkApplicationUpdating:
@@ -162,7 +163,7 @@ func (s *FlinkStateMachine) handle(ctx context.Context, application *v1alpha1.Fl
 			appErr = s.handleApplicationDeleting(ctx, application)
 		}
 
-		if !v1alpha1.IsRunningPhase(application.Status.Phase) {
+		if !v1alpha1.IsRunningPhase(appPhase) {
 			// Only update LastSeenError and thereby invoke error handling logic for
 			// non-Running phases
 			s.compareAndUpdateError(ctx, application, appErr)

--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -653,7 +653,9 @@ func (s *FlinkStateMachine) compareAndUpdateError(ctx context.Context, applicati
 		return
 	}
 
-	if err != nil {
+	if err == nil {
+		application.Status.LastSeenError = nil
+	} else {
 		if flinkAppError, ok := err.(*client.FlinkApplicationError); ok {
 			application.Status.LastSeenError = flinkAppError
 		} else {
@@ -663,11 +665,11 @@ func (s *FlinkStateMachine) compareAndUpdateError(ctx context.Context, applicati
 
 		now := v1.NewTime(s.clock.Now())
 		application.Status.LastSeenError.LastErrorUpdateTime = &now
+	}
 
-		updateErr := s.k8Cluster.UpdateK8Object(ctx, application)
-		if updateErr != nil {
-			logger.Errorf(ctx, "Updating last seen error failed with %v", updateErr)
-		}
+	updateErr := s.k8Cluster.UpdateK8Object(ctx, application)
+	if updateErr != nil {
+		logger.Errorf(ctx, "Updating last seen error failed with %v", updateErr)
 	}
 }
 


### PR DESCRIPTION
Currently, the `LastSeenError` is updated (on the k8s object) only if the error returned by a `handle<State>` call is not nil. This is a problem when `handle<State>` call succeeds after the first retry and `appErr` is now nil, the k8s object does not get updated and the error will continue to be retried until retries are exhausted. 

Changelog:
- Modify getAndUpdateError to compareAndUpdateError, which compares current and older error. If they are both nil, no updates to the k8s object are made. In all other cases, the k8s object is updated
- Call compareAndUpdateError irrespective of the value of appError
- Bug fix for the `IsTimeToRetry` logic which was evaluating a wrong value before and updated the corresponding test to not give false positives.