### PR TITLE
Update to the latest Flinkk8soperator release

### DIFF
--- a/deploy/flinkk8soperator.yaml
+++ b/deploy/flinkk8soperator.yaml
@@ -14,7 +14,7 @@ spec:
     metadata:
       labels:
         app: flinkoperator
-        app.kubernetes.io/version: 0.1.1
+        app.kubernetes.io/version: 0.1.3
     spec:
       serviceAccountName: flinkoperator
       volumes:
@@ -26,7 +26,7 @@ spec:
             path: config.yaml
       containers:
       - name: flinkoperator-gojson
-        image: docker.io/lyft/flinkk8soperator:v0.1.1
+        image: docker.io/lyft/flinkk8soperator:v0.1.3
         command:
         - flinkoperator
         args:


### PR DESCRIPTION
We have changed the Docker file in our examples. Our current examples only work with the latest release of the operator (due to the latest Flink HA issue fix).

cc @mwylde @glaksh100 