### PR TITLE
Update the documentation to reflect json naming schema

### DIFF
--- a/docs/crd.md
+++ b/docs/crd.md
@@ -5,19 +5,19 @@ The [flinkapplication](https://github.com/lyft/flinkk8soperator/blob/master/depl
 
 Below is the list of fields in the custom resource and their description
 
-* **Spec** `type:FlinkApplicationSpec required=True`
+* **spec** `type:FlinkApplicationSpec required=True`
   Contains the entire specification of the flink application.
 
-  * **Image** `type:string required=True`
+  * **image** `type:string required=True`
     The image name format should be registry/repository[:tag] to pull by tag, or registry/repository[@digest] to pull by digest
 
-  * **ImagePullPolicy** `type:v1.PullPolicy`
+  * **imagePullPolicy** `type:v1.PullPolicy`
     The default pull policy is IfNotPresent which causes the Kubelet to skip pulling an image if it already exists.
 
-  * **ImagePullSecrets** `type:[]v1.LocalObjectReference`
+  * **imagePullSecrets** `type:[]v1.LocalObjectReference`
     Indicates name of Secrets, Kubernetes should get the credentials from.
 
-  * **TaskManagerConfig** `type:TaskManagerConfig required=true`
+  * **taskManagerConfig** `type:TaskManagerConfig required=true`
     Configuration for the Flink task manager
 
     * **Resources** `type:ResourceRequirements`
@@ -37,7 +37,7 @@ Below is the list of fields in the custom resource and their description
     * **NodeSelector** `type:map[string]string`
       Configuration for the node selectors used for the task manager
 
-  * **JobManagerConfig** `type:JobManagerConfig`
+  * **jobManagerConfig** `type:JobManagerConfig`
     Configuration for the Flink job manager
 
     * **Resources** `type:ResourceRequirements`
@@ -58,37 +58,37 @@ Below is the list of fields in the custom resource and their description
     * **NodeSelector** `type:map[string]string`
       Configuration for the node selectors used for the job manager
 
-  * **JarName** `type:string required=true`
+  * **jarName** `type:string required=true`
     Name of the jar file to be run. The application image needs to ensure that the jar file is present at the right location, as
     the operator uses the Web API to submit jobs.
 
-  * **Parallelism** `type:int32 required=true`
+  * **parallelism** `type:int32 required=true`
     Job level parallelism for the Flink Job
 
-  * **EntryClass** `type:string`
+  * **entryClass** `type:string`
     Entry point for the Flink job
 
-  * **ProgramArgs** `type:string`
+  * **programArgs** `type:string`
     External configuration parameters to be passed as arguments to the job like input and output sources, etc
     
-  * **AllowNonRestoredState** `type:boolean`
+  * **allowNonRestoredState** `type:boolean`
     Skips savepoint operator state that cannot be mapped to the new program version  
 
-  * **SavepointInfo** `type:SavepointInfo`
+  * **savepointInfo** `type:SavepointInfo`
     Optional Savepoint info that can be passed in to indicate that the Flink job must resume from the corresponding savepoint.
 
-  * **FlinkVersion** `type:string required=true`
+  * **flinkVersion** `type:string required=true`
     The version of Flink to be managed. This version must match the version in the image.
 
-  * **FlinkConfig** `type:FlinkConfig`
+  * **flinkConfig** `type:FlinkConfig`
     Optional map of flink configuration, which passed on to the deployment as environment variable with `OPERATOR_FLINK_CONFIG`
 
-  * **DeploymentMode** `type:DeploymentMode`
+  * **deploymentMode** `type:DeploymentMode`
     Indicates the type of deployment that operator should perform if the custom resource is updated. Currently only Dual is supported.
 
     `Dual` This deployment mode is intended for applications where downtime during deployment needs to be as minimal as possible. In this deployment mode, the operator brings up a second Flink cluster with the new image, while the original Flink cluster is still active. Once the pods and containers in the new flink cluster are ready, the Operator cancels the job in the first Cluster with savepoint, deletes the cluster and starts the job in the second cluster. (More information in the state machine section below). This mode is suitable for real time processing applications.
 
-  * **DeleteMode** `type:DeleteMode`
+  * **deleteMode** `type:DeleteMode`
     Indicates how Flink jobs are torn down when the FlinkApplication resource is deleted
 
     `Savepoint` (default) The operator will take a final savepoint before cancelling the job, and will not tear down the cluster until a savepoint has succeeded.
@@ -97,11 +97,11 @@ Below is the list of fields in the custom resource and their description
 
     `None` The operator will immediately tear down the cluster
 
-  * **RestartNonce** `type:string`
+  * **restartNonce** `type:string`
     Can be set or modified to force a restart of the cluster
 
-  * **Volumes** `type:[]v1.Volume`
+  * **volumes** `type:[]v1.Volume`
     Represents a named volume in a pod that may be accessed by any container in the pod.
 
-  * **VolumeMounts** `type:[]v1.VolumeMount`
+  * **volumeMounts** `type:[]v1.VolumeMount`
     Describes a mounting of a Volume within a container.

--- a/docs/crd.md
+++ b/docs/crd.md
@@ -3,6 +3,8 @@ The [flinkapplication](https://github.com/lyft/flinkk8soperator/blob/master/depl
 
 [FlinkApplication Custom Resource Example](https://github.com/lyft/flinkk8soperator/blob/master/examples/wordcount/flink-operator-custom-resource.yaml)
 
+The type information is available here [FlinkApplication Type](https://github.com/lyft/flinkk8soperator/blob/master/pkg/apis/app/v1alpha1/types.go#L25)
+
 Below is the list of fields in the custom resource and their description
 
 * **spec** `type:FlinkApplicationSpec required=True`

--- a/docs/crd.md
+++ b/docs/crd.md
@@ -22,42 +22,42 @@ Below is the list of fields in the custom resource and their description
   * **taskManagerConfig** `type:TaskManagerConfig required=true`
     Configuration for the Flink task manager
 
-    * **Resources** `type:ResourceRequirements`
+    * **resources** `type:ResourceRequirements`
       Resources for the task manager. This includes cpu, memory, storage, and ephemeral-storage. If empty the operator will
       use a default value for cpu and memory.
 
-    * **EnvConfig** `type:EnvironmentConfig`
+    * **envConfig** `type:EnvironmentConfig`
       Configuration for setting environment variables in the task manager.
 
-    * **TaskSlots** `type:int32 required=true`
+    * **taskSlots** `type:int32 required=true`
       Number of task slots per task manager
 
-    * **OffHeapMemoryFraction** `type:float64`
+    * **offHeapMemoryFraction** `type:float64`
       A value between 0 and 1 that represents % of container memory dedicated to system / off heap. The
       remaining memory is allocated for heap.
 
-    * **NodeSelector** `type:map[string]string`
+    * **nodeSelector** `type:map[string]string`
       Configuration for the node selectors used for the task manager
 
   * **jobManagerConfig** `type:JobManagerConfig`
     Configuration for the Flink job manager
 
-    * **Resources** `type:ResourceRequirements`
+    * **resources** `type:ResourceRequirements`
       Resources for the job manager. This includes cpu, memory, storage, and ephemeral-storage. If empty the operator will
       use a default value for cpu and memory.
 
-    * **EnvConfig** `type:EnvironmentConfig`
+    * **envConfig** `type:EnvironmentConfig`
       Configuration for setting environment variables in the job manager.
 
-    * **Replicas** `type:int32 required=true`
+    * **replicas** `type:int32 required=true`
       Number of job managers for the flink cluster. If multiple job managers are provided, the user has to ensure that
       correct environment variables are set for High availability mode.
 
-    * **OffHeapMemoryFraction** `type:float64`
+    * **offHeapMemoryFraction** `type:float64`
       A value between 0 and 1 that represents % of container memory dedicated to system / off heap. The
       remaining memory is allocated for heap.
 
-    * **NodeSelector** `type:map[string]string`
+    * **nodeSelector** `type:map[string]string`
       Configuration for the node selectors used for the job manager
 
   * **jarName** `type:string required=true`


### PR DESCRIPTION
This updates the documentation to match the json/yaml serialization format to prevent confusion.

It also matches the validation defined here: https://github.com/lyft/flinkk8soperator/blob/master/deploy/crd.yaml#L16

cc @tweise 