### PR TITLE
Change invalid 'float' types to 'number' in crd validation schema

### DIFF
--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -87,7 +87,7 @@ spec:
                   type: integer
                   minimum: 1
                 offHeapMemoryFraction:
-                  type: float
+                  type: number
                 nodeSelector:
                   type: object
                   properties:
@@ -212,7 +212,7 @@ spec:
                   type: integer
                   minimum: 1
                 offHeapMemoryFraction:
-                  type: float
+                  type: number
                 nodeSelector:
                   type: object
                   properties:


### PR DESCRIPTION
From [the docs](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#type), floating point numbers have the type `number`, not `float`.