### PR TITLE
Fix retry maxbackoff issue

### DIFF
--- a/pkg/controller/flink/client/error_handler.go
+++ b/pkg/controller/flink/client/error_handler.go
@@ -141,8 +141,9 @@ func (r RetryHandler) WaitOnError(clock clock.Clock, lastUpdatedTime time.Time) 
 }
 func (r RetryHandler) GetRetryDelay(retryCount int32) time.Duration {
 	timeInMillis := int(r.baseBackOffDuration.Nanoseconds() / int64(time.Millisecond))
+	maxBackoffMillis := int(r.maxBackOffMillisDuration.Nanoseconds() / int64(time.Millisecond))
 	delay := 1 << uint(retryCount) * (rand.Intn(timeInMillis) + timeInMillis)
-	return time.Duration(min(delay, int(r.maxBackOffMillisDuration))) * time.Millisecond
+	return time.Duration(min(delay, maxBackoffMillis)) * time.Millisecond
 }
 func (r RetryHandler) IsTimeToRetry(clock clock.Clock, lastUpdatedTime time.Time, retryCount int32) bool {
 	elapsedTime := clock.Since(lastUpdatedTime)

--- a/pkg/controller/flink/client/error_handler_test.go
+++ b/pkg/controller/flink/client/error_handler_test.go
@@ -46,8 +46,9 @@ func TestErrors(t *testing.T) {
 
 func TestRetryHandler_GetRetryDelay(t *testing.T) {
 	retryHandler := getTestRetryer()
-	assert.True(t, retryHandler.GetRetryDelay(0) <= 50*time.Millisecond)
+	assert.True(t, retryHandler.GetRetryDelay(20) <= 50*time.Millisecond)
 	assert.True(t, retryHandler.GetRetryDelay(1) <= 50*time.Millisecond)
+	assert.True(t, retryHandler.GetRetryDelay(200) <= 50*time.Millisecond)
 }
 
 func TestRetryHandler_IsRetryRemaining(t *testing.T) {


### PR DESCRIPTION
TL;DR of issue and fix: https://play.golang.org/p/u3xKnyRNkl8. The min comparison was not happening on the same time scale. 
