### PR TITLE
[Backward Incompatible] Modifying Hash function to be consistent

### DIFF
--- a/pkg/controller/flink/container_utils.go
+++ b/pkg/controller/flink/container_utils.go
@@ -165,7 +165,7 @@ func HashForApplication(app *v1alpha1.FlinkApplication) string {
 	}
 
 	hasher := fnv.New32a()
-	_, err = printer.Fprintf(hasher, "%#v%#v", jmDeployment, tmDeployment)
+	_, err = printer.Fprintf(hasher, "%v%v", jmDeployment, tmDeployment)
 	if err != nil {
 		// the hasher cannot actually throw an error on write
 		panic(fmt.Sprintf("got error trying when writing to hash %v", err))

--- a/pkg/controller/flink/container_utils.go
+++ b/pkg/controller/flink/container_utils.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 	"hash/fnv"
 
-	"github.com/davecgh/go-spew/spew"
+	"github.com/benlaurie/objecthash/go/objecthash"
+
 	"github.com/lyft/flinkk8soperator/pkg/apis/app/v1alpha1"
 	"github.com/lyft/flinkk8soperator/pkg/controller/common"
 	"github.com/lyft/flinkk8soperator/pkg/controller/config"
@@ -127,48 +128,67 @@ func ImagePullPolicy(app *v1alpha1.FlinkApplication) v1.PullPolicy {
 	return app.Spec.ImagePullPolicy
 }
 
+func fromHashToByteArray(input [32]byte) []byte {
+	output := make([]byte, 32)
+	for idx, val := range input {
+		output[idx] = val
+	}
+	return output
+}
+
+// Generate a deterministic hash in bytes for the pb object
+func ComputeHash(deployment appsv1.Deployment) ([]byte, error) {
+	// json marshalling includes:
+	// - omitting empty values which supports backwards compatibility of old protobuf definitions
+	// We do not use protobuf marshalling because it does not guarantee stable output because of how it handles
+	// unknown fields and ordering of fields. https://github.com/protocolbuffers/protobuf/issues/2830
+	jsonObj, err := json.Marshal(deployment)
+	if err != nil {
+		return nil, err
+	}
+
+	// Deterministically hash the JSON object to a byte array. The library will sort the map keys of the JSON object
+	// so that we do not run into the issues from json marshalling.
+	hash, err := objecthash.CommonJSONHash(string(jsonObj))
+	if err != nil {
+		return nil, err
+	}
+
+	return fromHashToByteArray(hash), err
+}
+
 // Returns an 8 character hash sensitive to the application name, labels, annotations, and spec.
 // TODO: we may need to add collision-avoidance to this
 func HashForApplication(app *v1alpha1.FlinkApplication) string {
-	printer := spew.ConfigState{
-		Indent:                  " ",
-		SortKeys:                true,
-		DisableMethods:          true,
-		DisableCapacities:       true,
-		SpewKeys:                true,
-		DisablePointerAddresses: true,
-	}
-
 	// we round-trip through json to normalize the deployment objects
 	jmDeployment := jobmanagerTemplate(app)
 	jmDeployment.OwnerReferences = make([]metav1.OwnerReference, 0)
 
-	// these steps should not be able to fail, so we panic instead of returning an error
-	jm, err := json.Marshal(jmDeployment)
-	if err != nil {
-		panic("failed to marshal deployment")
-	}
-	err = json.Unmarshal(jm, &jmDeployment)
-	if err != nil {
-		panic("failed to unmarshal deployment")
-	}
-
 	tmDeployment := taskmanagerTemplate(app)
 	tmDeployment.OwnerReferences = make([]metav1.OwnerReference, 0)
-	tm, err := json.Marshal(tmDeployment)
+
+	jmHashBytes, err := ComputeHash(*jmDeployment)
 	if err != nil {
-		panic("failed to marshal deployment")
+		// the hasher cannot actually throw an error on write
+		panic(fmt.Sprintf("got error trying when computing hash %v", err))
 	}
-	err = json.Unmarshal(tm, &tmDeployment)
+
+	tmHashBytes, err := ComputeHash(*tmDeployment)
 	if err != nil {
-		panic("failed to unmarshal deployment")
+		// the hasher cannot actually throw an error on write
+		panic(fmt.Sprintf("got error trying when computing hash %v", err))
 	}
 
 	hasher := fnv.New32a()
-	_, err = printer.Fprintf(hasher, "%v%v", jmDeployment, tmDeployment)
+	_, err = hasher.Write(jmHashBytes)
 	if err != nil {
 		// the hasher cannot actually throw an error on write
-		panic(fmt.Sprintf("got error trying when writing to hash %v", err))
+		panic(fmt.Sprintf("got error trying when writing to hasher %v", err))
+	}
+	_, err = hasher.Write(tmHashBytes)
+	if err != nil {
+		// the hasher cannot actually throw an error on write
+		panic(fmt.Sprintf("got error trying when writing to hasher %v", err))
 	}
 
 	return fmt.Sprintf("%08x", hasher.Sum32())

--- a/pkg/controller/flink/container_utils.go
+++ b/pkg/controller/flink/container_utils.go
@@ -137,11 +137,9 @@ func fromHashToByteArray(input [32]byte) []byte {
 }
 
 // Generate a deterministic hash in bytes for the pb object
-func ComputeHash(deployment appsv1.Deployment) ([]byte, error) {
+func ComputeDeploymentHash(deployment appsv1.Deployment) ([]byte, error) {
 	// json marshalling includes:
 	// - omitting empty values which supports backwards compatibility of old protobuf definitions
-	// We do not use protobuf marshalling because it does not guarantee stable output because of how it handles
-	// unknown fields and ordering of fields. https://github.com/protocolbuffers/protobuf/issues/2830
 	jsonObj, err := json.Marshal(deployment)
 	if err != nil {
 		return nil, err
@@ -167,13 +165,13 @@ func HashForApplication(app *v1alpha1.FlinkApplication) string {
 	tmDeployment := taskmanagerTemplate(app)
 	tmDeployment.OwnerReferences = make([]metav1.OwnerReference, 0)
 
-	jmHashBytes, err := ComputeHash(*jmDeployment)
+	jmHashBytes, err := ComputeDeploymentHash(*jmDeployment)
 	if err != nil {
 		// the hasher cannot actually throw an error on write
 		panic(fmt.Sprintf("got error trying when computing hash %v", err))
 	}
 
-	tmHashBytes, err := ComputeHash(*tmDeployment)
+	tmHashBytes, err := ComputeDeploymentHash(*tmDeployment)
 	if err != nil {
 		// the hasher cannot actually throw an error on write
 		panic(fmt.Sprintf("got error trying when computing hash %v", err))

--- a/pkg/controller/flink/flink_test.go
+++ b/pkg/controller/flink/flink_test.go
@@ -29,7 +29,7 @@ import (
 const testImage = "123.xyz.com/xx:11ae1218924428faabd9b64423fa0c332efba6b2"
 
 // Note: if you find yourself changing this to fix a test, that should be treated as a breaking API change
-const testAppHash = "de844839"
+const testAppHash = "c503e97e"
 const testAppName = "app-name"
 const testNamespace = "ns"
 const testJobID = "j1"

--- a/pkg/controller/flink/job_manager_controller_test.go
+++ b/pkg/controller/flink/job_manager_controller_test.go
@@ -55,7 +55,7 @@ func TestJobManagerCreateSuccess(t *testing.T) {
 		"flink-job-properties": "jarName: " + testJarName + "\nparallelism: 8\nentryClass:" + testEntryClass + "\nprogramArgs:\"" + testProgramArgs + "\"",
 	}
 	app.Annotations = annotations
-	hash := "390e4c6d"
+	hash := "d62c9c38"
 	expectedLabels := map[string]string{
 		"flink-app":             "app-name",
 		"flink-app-hash":        hash,
@@ -129,7 +129,7 @@ func TestJobManagerHACreateSuccess(t *testing.T) {
 	app.Spec.FlinkConfig = map[string]interface{}{
 		"high-availability": "zookeeper",
 	}
-	hash := "fda698ef"
+	hash := "063e33b7"
 	expectedLabels := map[string]string{
 		"flink-app":             "app-name",
 		"flink-app-hash":        hash,

--- a/pkg/controller/flink/task_manager_controller_test.go
+++ b/pkg/controller/flink/task_manager_controller_test.go
@@ -60,7 +60,7 @@ func TestTaskManagerCreateSuccess(t *testing.T) {
 		"flink-job-properties": "jarName: test.jar\nparallelism: 8\nentryClass:com.test.MainClass\nprogramArgs:\"--test\"",
 	}
 
-	hash := "390e4c6d"
+	hash := "d62c9c38"
 
 	app.Annotations = annotations
 	expectedLabels := map[string]string{
@@ -107,7 +107,7 @@ func TestTaskManagerHACreateSuccess(t *testing.T) {
 		"flink-job-properties": "jarName: test.jar\nparallelism: 8\nentryClass:com.test.MainClass\nprogramArgs:\"--test\"",
 	}
 
-	hash := "fda698ef"
+	hash := "063e33b7"
 	app.Spec.FlinkConfig = map[string]interface{}{
 		"high-availability": "zookeeper",
 	}


### PR DESCRIPTION
Currently, whenever we upgrade "client-go", "apimachinery", "api"  the hash value also changes.

This PR changes the hashing mechanism

I have tested this across these two SHAs - `9aaa992bf12ecd0577a4b0f7dfb1c248a93d47ea` and `f9206646aaffb7763657ec9e794bc979b0b4722b`. The hash does not change.

