### PR TITLE
Adding S3 client libraries

### DIFF
--- a/examples/wordcount/Dockerfile
+++ b/examples/wordcount/Dockerfile
@@ -60,6 +60,9 @@ RUN set -ex; \
   tar -xf flink.tgz --strip-components=1; \
   rm flink.tgz; \
   \
+  cp ./opt/flink-s3-fs-presto-1.8.1.jar ./lib/;\
+  cp ./opt/flink-s3-fs-hadoop-1.8.1.jar ./lib/;\
+  \  
   chown -R flink:flink .;
 
 # Needed on OpenShift for the entrypoint script to work


### PR DESCRIPTION
Adding S3 client libraries (simply copying them from `opt` to `lib` on the Flink installation folder) so that examples can make use of S3 filesystems (`s3a://` and `s3p://` schemes)