### PR TITLE
Add support for multiple versions

### DIFF
--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -13,6 +13,13 @@ spec:
       - flinkapp
   scope: Namespaced
   version: v1beta1
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+    - name: v1alpha1
+      served: true
+      storage: false
   validation:
     # openAPIV3Schema is the schema for validating custom objects.
     openAPIV3Schema:


### PR DESCRIPTION
This change adds support for multiple versions (v1alpha1 and v1beta1) in the crd, as described [here](https://v1-14.docs.kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning/#specify-multiple-versions).

The latest version of v1alpha1 and v1beta1 are compatible (i.e., the current version of the operator can handle both) so this allows the migration to v1beta1 to be non-breaking for existing users.