### PR TITLE
For now the equality checks for Deployment matches

### DIFF
--- a/pkg/controller/flink/container_utils.go
+++ b/pkg/controller/flink/container_utils.go
@@ -259,9 +259,11 @@ func containersEqual(a *v1.Container, b *v1.Container) bool {
 // Returns true if there are no relevant differences between the deployments. This should be used only to determine
 // that two deployments correspond to the same FlinkApplication, not as a general notion of equality.
 func DeploymentsEqual(a *appsv1.Deployment, b *appsv1.Deployment) bool {
-	if !apiequality.Semantic.DeepEqual(a.Spec.Template.Spec.Volumes, b.Spec.Template.Spec.Volumes) {
-		return false
-	}
+	// The deployment object returned has EmptyDirVolumeSource set as empty object in volume
+	// TODO: Figure out better equals check or remove all together.
+	// if !apiequality.Semantic.DeepEqual(a.Spec.Template.Spec.Volumes, b.Spec.Template.Spec.Volumes) {
+	//	return false
+	//}
 	if len(a.Spec.Template.Spec.Containers) == 0 ||
 		len(b.Spec.Template.Spec.Containers) == 0 ||
 		!containersEqual(&a.Spec.Template.Spec.Containers[0], &b.Spec.Template.Spec.Containers[0]) {

--- a/pkg/controller/flink/container_utils.go
+++ b/pkg/controller/flink/container_utils.go
@@ -1,11 +1,8 @@
 package flink
 
 import (
-	"context"
 	"fmt"
 	"hash/fnv"
-
-	"github.com/lyft/flytestdlib/logger"
 
 	"github.com/benlaurie/objecthash/go/objecthash"
 
@@ -262,10 +259,11 @@ func containersEqual(a *v1.Container, b *v1.Container) bool {
 // Returns true if there are no relevant differences between the deployments. This should be used only to determine
 // that two deployments correspond to the same FlinkApplication, not as a general notion of equality.
 func DeploymentsEqual(a *appsv1.Deployment, b *appsv1.Deployment) bool {
-	if !apiequality.Semantic.DeepEqual(a.Spec.Template.Spec.Volumes, b.Spec.Template.Spec.Volumes) {
-		logger.Infof(context.Background(), "%v %v", a.Spec.Template.Spec.Volumes, b.Spec.Template.Spec.Volumes)
-		return false
-	}
+	// The deployment object returned has EmptyDirVolumeSource set as empty object in volume
+	// TODO: Figure out better equals check or remove all together.
+	// if !apiequality.Semantic.DeepEqual(a.Spec.Template.Spec.Volumes, b.Spec.Template.Spec.Volumes) {
+	//	return false
+	//}
 	if len(a.Spec.Template.Spec.Containers) == 0 ||
 		len(b.Spec.Template.Spec.Containers) == 0 ||
 		!containersEqual(&a.Spec.Template.Spec.Containers[0], &b.Spec.Template.Spec.Containers[0]) {

--- a/pkg/controller/flink/container_utils.go
+++ b/pkg/controller/flink/container_utils.go
@@ -1,8 +1,11 @@
 package flink
 
 import (
+	"context"
 	"fmt"
 	"hash/fnv"
+
+	"github.com/lyft/flytestdlib/logger"
 
 	"github.com/benlaurie/objecthash/go/objecthash"
 
@@ -259,11 +262,10 @@ func containersEqual(a *v1.Container, b *v1.Container) bool {
 // Returns true if there are no relevant differences between the deployments. This should be used only to determine
 // that two deployments correspond to the same FlinkApplication, not as a general notion of equality.
 func DeploymentsEqual(a *appsv1.Deployment, b *appsv1.Deployment) bool {
-	// The deployment object returned has EmptyDirVolumeSource set as empty object in volume
-	// TODO: Figure out better equals check or remove all together.
-	// if !apiequality.Semantic.DeepEqual(a.Spec.Template.Spec.Volumes, b.Spec.Template.Spec.Volumes) {
-	//	return false
-	//}
+	if !apiequality.Semantic.DeepEqual(a.Spec.Template.Spec.Volumes, b.Spec.Template.Spec.Volumes) {
+		logger.Infof(context.Background(), "%v %v", a.Spec.Template.Spec.Volumes, b.Spec.Template.Spec.Volumes)
+		return false
+	}
 	if len(a.Spec.Template.Spec.Containers) == 0 ||
 		len(b.Spec.Template.Spec.Containers) == 0 ||
 		!containersEqual(&a.Spec.Template.Spec.Containers[0], &b.Spec.Template.Spec.Containers[0]) {

--- a/pkg/controller/flink/container_utils_test.go
+++ b/pkg/controller/flink/container_utils_test.go
@@ -75,29 +75,3 @@ func TestHashForDifferentResourceScales(t *testing.T) {
 
 	assert.Equal(t, HashForApplication(&app1), HashForApplication(&app2))
 }
-
-func TestContainersEqual(t *testing.T) {
-	app := getFlinkTestApp()
-	d1 := FetchJobMangerDeploymentCreateObj(&app, "hash")
-	d2 := FetchJobMangerDeploymentCreateObj(&app, "hash")
-
-	assert.True(t, DeploymentsEqual(d1, d2))
-
-	d1 = FetchTaskMangerDeploymentCreateObj(&app, HashForApplication(&app))
-	d2 = FetchTaskMangerDeploymentCreateObj(&app, HashForApplication(&app))
-
-	assert.True(t, DeploymentsEqual(d1, d2))
-
-	d3 := d1.DeepCopy()
-	d3.Spec.Template.Spec.Containers[0].ImagePullPolicy = "Always"
-	assert.False(t, DeploymentsEqual(d3, d2))
-
-	d3 = d1.DeepCopy()
-	replicas := int32(13)
-	d3.Spec.Replicas = &replicas
-	assert.False(t, DeploymentsEqual(d3, d2))
-
-	d3 = d1.DeepCopy()
-	d3.Annotations[RestartNonce] = "x"
-	assert.False(t, DeploymentsEqual(d3, d2))
-}

--- a/pkg/controller/flink/job_manager_controller.go
+++ b/pkg/controller/flink/job_manager_controller.go
@@ -352,6 +352,6 @@ func FetchJobMangerDeploymentCreateObj(app *v1beta1.FlinkApplication, hash strin
 }
 
 func JobManagerDeploymentMatches(deployment *v1.Deployment, application *v1beta1.FlinkApplication, hash string) bool {
-	deploymentName := getJobgitManagerName(application, hash)
+	deploymentName := getJobManagerName(application, hash)
 	return deployment.Name == deploymentName
 }

--- a/pkg/controller/flink/job_manager_controller.go
+++ b/pkg/controller/flink/job_manager_controller.go
@@ -351,7 +351,7 @@ func FetchJobMangerDeploymentCreateObj(app *v1beta1.FlinkApplication, hash strin
 	return template
 }
 
-func JobManagerDeploymentMatches(deployment *v1.Deployment, application *v1beta1.FlinkApplication) bool {
-	deploymentFromApp := FetchJobMangerDeploymentCreateObj(application, HashForApplication(application))
-	return DeploymentsEqual(deploymentFromApp, deployment)
+func JobManagerDeploymentMatches(deployment *v1.Deployment, application *v1beta1.FlinkApplication, hash string) bool {
+	deploymentName := getJobManagerName(application, hash)
+	return deployment.Name == deploymentName
 }

--- a/pkg/controller/flink/job_manager_controller.go
+++ b/pkg/controller/flink/job_manager_controller.go
@@ -352,6 +352,6 @@ func FetchJobMangerDeploymentCreateObj(app *v1beta1.FlinkApplication, hash strin
 }
 
 func JobManagerDeploymentMatches(deployment *v1.Deployment, application *v1beta1.FlinkApplication, hash string) bool {
-	deploymentName := getJobManagerName(application, hash)
+	deploymentName := getJobgitManagerName(application, hash)
 	return deployment.Name == deploymentName
 }

--- a/pkg/controller/flink/task_manager_controller.go
+++ b/pkg/controller/flink/task_manager_controller.go
@@ -230,6 +230,5 @@ func FetchTaskMangerDeploymentCreateObj(app *v1beta1.FlinkApplication, hash stri
 
 func TaskManagerDeploymentMatches(deployment *v1.Deployment, application *v1beta1.FlinkApplication, hash string) bool {
 	deploymentName := getTaskManagerName(application, hash)
-	logger.Errorf(context.Background(), "%s %s", deployment.Name, deploymentName)
 	return deployment.Name == deploymentName
 }

--- a/pkg/controller/flink/task_manager_controller.go
+++ b/pkg/controller/flink/task_manager_controller.go
@@ -228,7 +228,8 @@ func FetchTaskMangerDeploymentCreateObj(app *v1beta1.FlinkApplication, hash stri
 	return template
 }
 
-func TaskManagerDeploymentMatches(deployment *v1.Deployment, application *v1beta1.FlinkApplication) bool {
-	deploymentFromApp := FetchTaskMangerDeploymentCreateObj(application, HashForApplication(application))
-	return DeploymentsEqual(deploymentFromApp, deployment)
+func TaskManagerDeploymentMatches(deployment *v1.Deployment, application *v1beta1.FlinkApplication, hash string) bool {
+	deploymentName := getTaskManagerName(application, hash)
+	logger.Errorf(context.Background(), "%s %s", deployment.Name, deploymentName)
+	return deployment.Name == deploymentName
 }

--- a/pkg/controller/k8/cluster.go
+++ b/pkg/controller/k8/cluster.go
@@ -118,7 +118,6 @@ func (k *Cluster) GetDeploymentsWithLabel(ctx context.Context, namespace string,
 	}
 	labelSelector := labels.SelectorFromSet(labelMap)
 	options := &client.ListOptions{
-		Namespace:     namespace,
 		LabelSelector: labelSelector,
 	}
 	listOptionsFunc := client.UseListOptions(options)
@@ -150,7 +149,6 @@ func (k *Cluster) GetServicesWithLabel(ctx context.Context, namespace string, la
 	}
 	labelSelector := labels.SelectorFromSet(labelMap)
 	options := &client.ListOptions{
-		Namespace:     namespace,
 		LabelSelector: labelSelector,
 	}
 	listOptionsFunc := client.UseListOptions(options)

--- a/pkg/controller/k8/cluster.go
+++ b/pkg/controller/k8/cluster.go
@@ -118,6 +118,7 @@ func (k *Cluster) GetDeploymentsWithLabel(ctx context.Context, namespace string,
 	}
 	labelSelector := labels.SelectorFromSet(labelMap)
 	options := &client.ListOptions{
+		Namespace: namespace,
 		LabelSelector: labelSelector,
 	}
 	listOptionsFunc := client.UseListOptions(options)
@@ -149,6 +150,7 @@ func (k *Cluster) GetServicesWithLabel(ctx context.Context, namespace string, la
 	}
 	labelSelector := labels.SelectorFromSet(labelMap)
 	options := &client.ListOptions{
+		Namespace: namespace,
 		LabelSelector: labelSelector,
 	}
 	listOptionsFunc := client.UseListOptions(options)

--- a/pkg/controller/k8/cluster.go
+++ b/pkg/controller/k8/cluster.go
@@ -118,7 +118,7 @@ func (k *Cluster) GetDeploymentsWithLabel(ctx context.Context, namespace string,
 	}
 	labelSelector := labels.SelectorFromSet(labelMap)
 	options := &client.ListOptions{
-		Namespace: namespace,
+		Namespace:     namespace,
 		LabelSelector: labelSelector,
 	}
 	listOptionsFunc := client.UseListOptions(options)
@@ -150,7 +150,7 @@ func (k *Cluster) GetServicesWithLabel(ctx context.Context, namespace string, la
 	}
 	labelSelector := labels.SelectorFromSet(labelMap)
 	options := &client.ListOptions{
-		Namespace: namespace,
+		Namespace:     namespace,
 		LabelSelector: labelSelector,
 	}
 	listOptionsFunc := client.UseListOptions(options)


### PR DESCRIPTION
Under deploymentEquals,

The volume returned from the API contains `EmptyDirVolumeSource` set to empty object, even though it is set to nil when creation. 

There are other cases as well like `defaultMode: 420` in configmap.

Removing the equality checks, as hash collisions are rare, and equality check is not right