### PR TITLE
Pass the namespace in the client.ListOptions

### DIFF
--- a/pkg/controller/k8/cluster.go
+++ b/pkg/controller/k8/cluster.go
@@ -118,6 +118,7 @@ func (k *Cluster) GetDeploymentsWithLabel(ctx context.Context, namespace string,
 	}
 	labelSelector := labels.SelectorFromSet(labelMap)
 	options := &client.ListOptions{
+		Namespace:     namespace,
 		LabelSelector: labelSelector,
 	}
 	listOptionsFunc := client.UseListOptions(options)
@@ -149,6 +150,7 @@ func (k *Cluster) GetServicesWithLabel(ctx context.Context, namespace string, la
 	}
 	labelSelector := labels.SelectorFromSet(labelMap)
 	options := &client.ListOptions{
+		Namespace:     namespace,
 		LabelSelector: labelSelector,
 	}
 	listOptionsFunc := client.UseListOptions(options)


### PR DESCRIPTION
We missed passing namespace to ListOptions.

Thanks @yuchaoran2011 for catching