### PR TITLE
Add Prometheus annotations

### DIFF
--- a/deploy/config.yaml
+++ b/deploy/config.yaml
@@ -8,5 +8,6 @@ data:
   config: |-
     operator:
       ingressUrlFormat: "{{$jobCluster}}.{ingress_suffix}"
+      prometheusPort: 9249
     logger:
       level: 4

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -18,12 +18,13 @@ type Config struct {
 	ProfilerPort          config.Port     `json:"prof-port" pflag:"\"10254\",Profiler port"`
 	FlinkIngressURLFormat string          `json:"ingressUrlFormat"`
 	UseProxy              bool            `json:"useKubectlProxy"`
-	ProxyPort             config.Port     `json:"ProxyPort" pflag:"\"8001\",The port at which flink cluster runs locally"`
+	ProxyPort             config.Port     `json:"proxyPort" pflag:"\"8001\",The port at which flink cluster runs locally"`
 	ContainerNameFormat   string          `json:"containerNameFormat"`
 	Workers               int             `json:"workers" pflag:"4,Number of routines to process custom resource"`
 	BaseBackoffDuration   config.Duration `json:"baseBackoffDuration" pflag:"\"100ms\",Determines the base backoff for exponential retries."`
 	MaxBackoffDuration    config.Duration `json:"maxBackoffDuration" pflag:"\"30s\",Determines the max backoff for exponential retries."`
 	MaxErrDuration        config.Duration `json:"maxErrDuration" pflag:"\"5m\",Determines the max time to wait on errors."`
+	PrometheusPort        config.Port     `json:"prometheusPort" pflag:"\"9249\",The port at which Flink metrics are exported from job manager and task manager pods"`
 }
 
 func GetConfig() *Config {

--- a/pkg/controller/flink/container_utils.go
+++ b/pkg/controller/flink/container_utils.go
@@ -3,6 +3,7 @@ package flink
 import (
 	"fmt"
 	"hash/fnv"
+	"strconv"
 
 	"github.com/benlaurie/objecthash/go/objecthash"
 
@@ -58,6 +59,13 @@ func getCommonAnnotations(app *v1beta1.FlinkApplication) map[string]string {
 		annotations[RestartNonce] = app.Spec.RestartNonce
 	}
 	return annotations
+}
+
+func GetPrometheusAnnotations(port int) map[string]string {
+	return map[string]string{
+		"prometheus.io/scrape": "true",
+		"prometheus.io/port":   strconv.Itoa(port),
+	}
 }
 
 func GetAWSServiceEnv() []v1.EnvVar {

--- a/pkg/controller/flink/container_utils.go
+++ b/pkg/controller/flink/container_utils.go
@@ -34,6 +34,7 @@ const (
 	FlinkAppHash                     = "flink-app-hash"
 	FlinkJobProperties               = "flink-job-properties"
 	PrometheusScrape                 = "prometheus.io/scrape"
+	PrometheusPort                   = "prometheus.io/port"
 	RestartNonce                     = "restart-nonce"
 )
 
@@ -53,6 +54,7 @@ func getCommonAppLabels(app *v1beta1.FlinkApplication) map[string]string {
 func getCommonAnnotations(app *v1beta1.FlinkApplication) map[string]string {
 	annotations := common.DuplicateMap(app.Annotations)
 	annotations[PrometheusScrape] = "true"
+	annotations[PrometheusPort] = "9249"
 	annotations[FlinkJobProperties] = fmt.Sprintf(
 		"jarName: %s\nparallelism: %d\nentryClass:%s\nprogramArgs:\"%s\"",
 		app.Spec.JarName, app.Spec.Parallelism, app.Spec.EntryClass, app.Spec.ProgramArgs)

--- a/pkg/controller/flink/container_utils.go
+++ b/pkg/controller/flink/container_utils.go
@@ -33,8 +33,6 @@ const (
 	FlinkDeploymentTypeTaskmanager   = "taskmanager"
 	FlinkAppHash                     = "flink-app-hash"
 	FlinkJobProperties               = "flink-job-properties"
-	PrometheusScrape                 = "prometheus.io/scrape"
-	PrometheusPort                   = "prometheus.io/port"
 	RestartNonce                     = "restart-nonce"
 )
 
@@ -53,8 +51,6 @@ func getCommonAppLabels(app *v1beta1.FlinkApplication) map[string]string {
 
 func getCommonAnnotations(app *v1beta1.FlinkApplication) map[string]string {
 	annotations := common.DuplicateMap(app.Annotations)
-	annotations[PrometheusScrape] = "true"
-	annotations[PrometheusPort] = "9249"
 	annotations[FlinkJobProperties] = fmt.Sprintf(
 		"jarName: %s\nparallelism: %d\nentryClass:%s\nprogramArgs:\"%s\"",
 		app.Spec.JarName, app.Spec.Parallelism, app.Spec.EntryClass, app.Spec.ProgramArgs)

--- a/pkg/controller/flink/container_utils.go
+++ b/pkg/controller/flink/container_utils.go
@@ -33,6 +33,7 @@ const (
 	FlinkDeploymentTypeTaskmanager   = "taskmanager"
 	FlinkAppHash                     = "flink-app-hash"
 	FlinkJobProperties               = "flink-job-properties"
+	PrometheusScrape                 = "prometheus.io/scrape"
 	RestartNonce                     = "restart-nonce"
 )
 
@@ -51,6 +52,7 @@ func getCommonAppLabels(app *v1beta1.FlinkApplication) map[string]string {
 
 func getCommonAnnotations(app *v1beta1.FlinkApplication) map[string]string {
 	annotations := common.DuplicateMap(app.Annotations)
+	annotations[PrometheusScrape] = "true"
 	annotations[FlinkJobProperties] = fmt.Sprintf(
 		"jarName: %s\nparallelism: %d\nentryClass:%s\nprogramArgs:\"%s\"",
 		app.Spec.JarName, app.Spec.Parallelism, app.Spec.EntryClass, app.Spec.ProgramArgs)

--- a/pkg/controller/flink/job_manager_controller.go
+++ b/pkg/controller/flink/job_manager_controller.go
@@ -307,7 +307,10 @@ func jobmanagerTemplate(app *v1beta1.FlinkApplication) *v1.Deployment {
 		ObjectMeta: metaV1.ObjectMeta{
 			Namespace:   app.Namespace,
 			Labels:      labels,
-			Annotations: getCommonAnnotations(app),
+			Annotations: map[string]string{
+				"prometheus.io/scrape": "true",
+				"prometheus.io/port": "9249",
+			},
 			OwnerReferences: []metaV1.OwnerReference{
 				*metaV1.NewControllerRef(app, app.GroupVersionKind()),
 			},

--- a/pkg/controller/flink/job_manager_controller.go
+++ b/pkg/controller/flink/job_manager_controller.go
@@ -307,10 +307,7 @@ func jobmanagerTemplate(app *v1beta1.FlinkApplication) *v1.Deployment {
 		ObjectMeta: metaV1.ObjectMeta{
 			Namespace:   app.Namespace,
 			Labels:      labels,
-			Annotations: map[string]string{
-				"prometheus.io/scrape": "true",
-				"prometheus.io/port": "9249",
-			},
+			Annotations: GetPrometheusAnnotations(config.GetConfig().PrometheusPort.Port),
 			OwnerReferences: []metaV1.OwnerReference{
 				*metaV1.NewControllerRef(app, app.GroupVersionKind()),
 			},

--- a/pkg/controller/flink/task_manager_controller.go
+++ b/pkg/controller/flink/task_manager_controller.go
@@ -199,10 +199,7 @@ func taskmanagerTemplate(app *v1beta1.FlinkApplication) *v1.Deployment {
 				ObjectMeta: metaV1.ObjectMeta{
 					Namespace:   app.Namespace,
 					Labels:      labels,
-					Annotations: map[string]string{
-						"prometheus.io/scrape": "true",
-						"prometheus.io/port": "9249",
-					},
+					Annotations: GetPrometheusAnnotations(config.GetConfig().PrometheusPort.Port),
 				},
 				Spec: coreV1.PodSpec{
 					Containers: []coreV1.Container{

--- a/pkg/controller/flink/task_manager_controller.go
+++ b/pkg/controller/flink/task_manager_controller.go
@@ -199,7 +199,10 @@ func taskmanagerTemplate(app *v1beta1.FlinkApplication) *v1.Deployment {
 				ObjectMeta: metaV1.ObjectMeta{
 					Namespace:   app.Namespace,
 					Labels:      labels,
-					Annotations: app.Annotations,
+					Annotations: map[string]string{
+						"prometheus.io/scrape": "true",
+						"prometheus.io/port": "9249",
+					},
 				},
 				Spec: coreV1.PodSpec{
 					Containers: []coreV1.Container{


### PR DESCRIPTION
We've observed that by passing in the appropriate settings in `flink-conf.yaml` when building the Flink application image, Prometheus metrics can be properly exported from the JM and TM pods. But we've noticed that Prometheus is not able to scrape the exported metrics. The consequence is that from the Prometheus UI, the metrics won't show up and therefore no queryable. 

To let Prometheus discover exported metrics, the JM and TM pods need to have the right annotations, which are added in this PR. The default port is set to `9249`, which is the default value used in Flink documentation too.