### PR TITLE
Pass the Flink application annotations to Ingress and Service

### DIFF
--- a/pkg/controller/flink/ingress.go
+++ b/pkg/controller/flink/ingress.go
@@ -23,13 +23,14 @@ func GetFlinkUIIngressURL(jobName string) string {
 }
 
 func FetchJobManagerIngressCreateObj(app *flinkapp.FlinkApplication) *v1beta1.Ingress {
-	podLabels := common.DuplicateMap(app.Labels)
-	podLabels = common.CopyMap(podLabels, k8.GetAppLabel(app.Name))
+	ingressLabels := common.DuplicateMap(app.Labels)
+	ingressLabels = common.CopyMap(ingressLabels, k8.GetAppLabel(app.Name))
 
 	ingressMeta := v1.ObjectMeta{
-		Name:      app.Name,
-		Labels:    podLabels,
-		Namespace: app.Namespace,
+		Name:        app.Name,
+		Annotations: app.Annotations,
+		Labels:      ingressLabels,
+		Namespace:   app.Namespace,
 		OwnerReferences: []v1.OwnerReference{
 			*v1.NewControllerRef(app, app.GroupVersionKind()),
 		},

--- a/pkg/controller/flink/job_manager_controller.go
+++ b/pkg/controller/flink/job_manager_controller.go
@@ -187,8 +187,9 @@ func FetchJobManagerServiceCreateObj(app *v1beta1.FlinkApplication, hash string)
 			Kind:       k8.Service,
 		},
 		ObjectMeta: metaV1.ObjectMeta{
-			Name:      jmServiceName,
-			Namespace: app.Namespace,
+			Name:        jmServiceName,
+			Namespace:   app.Namespace,
+			Annotations: app.Annotations,
 			OwnerReferences: []metaV1.OwnerReference{
 				*metaV1.NewControllerRef(app, app.GroupVersionKind()),
 			},


### PR DESCRIPTION
We currently only pass the annotations to JM/TM deployments. This change pass the annotations to Ingress and service as well.
