### PR TITLE
[STRMCMP-610] Fix flink config rendering

### DIFF
--- a/pkg/controller/flink/config.go
+++ b/pkg/controller/flink/config.go
@@ -116,7 +116,6 @@ func renderFlinkConfig(app *v1beta1.FlinkApplication) (string, error) {
 	(*config)["jobmanager.heap.size"] = getJobManagerHeapMemory(app)
 	(*config)["taskmanager.heap.size"] = getTaskManagerHeapMemory(app)
 
-
 	// get the keys for the map
 	var keys = make([]string, len(*config))
 	i := 0
@@ -137,15 +136,13 @@ func renderFlinkConfig(app *v1beta1.FlinkApplication) (string, error) {
 		case int, uint, int32, uint32, int64, uint64, bool, float32, float64:
 			vStr = fmt.Sprintf("%v", v)
 		case string:
-			vStr = fmt.Sprintf("%s", v)
-
+			vStr = v
 		default:
 			return "", fmt.Errorf("invalid type in flink config: %T", v)
 		}
 
 		_, _ = fmt.Fprintf(&s, "%s: %s\n", k, vStr)
 	}
-
 
 	return s.String(), nil
 }

--- a/pkg/controller/flink/config.go
+++ b/pkg/controller/flink/config.go
@@ -1,10 +1,11 @@
 package flink
 
 import (
+	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/lyft/flinkk8soperator/pkg/apis/app/v1beta1"
-	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -115,11 +116,38 @@ func renderFlinkConfig(app *v1beta1.FlinkApplication) (string, error) {
 	(*config)["jobmanager.heap.size"] = getJobManagerHeapMemory(app)
 	(*config)["taskmanager.heap.size"] = getTaskManagerHeapMemory(app)
 
-	b, err := yaml.Marshal(config)
-	if err != nil {
-		return "", err
+
+	// get the keys for the map
+	var keys = make([]string, len(*config))
+	i := 0
+	for k := range *config {
+		keys[i] = k
+		i++
 	}
-	return string(b), nil
+
+	// sort them to provide a stable iteration order
+	sort.Strings(keys)
+
+	// print them in order
+	var s strings.Builder
+	for _, k := range keys {
+		var vStr string
+
+		switch v := (*config)[k].(type) {
+		case int, uint, int32, uint32, int64, uint64, bool, float32, float64:
+			vStr = fmt.Sprintf("%v", v)
+		case string:
+			vStr = fmt.Sprintf("%s", v)
+
+		default:
+			return "", fmt.Errorf("invalid type in flink config: %T", v)
+		}
+
+		_, _ = fmt.Fprintf(&s, "%s: %s\n", k, vStr)
+	}
+
+
+	return s.String(), nil
 }
 
 func isHAEnabled(flinkConfig v1beta1.FlinkConfig) bool {

--- a/pkg/controller/flink/config_test.go
+++ b/pkg/controller/flink/config_test.go
@@ -28,6 +28,7 @@ func TestRenderFlinkConfigOverrides(t *testing.T) {
 				"taskmanager.network.memory.fraction":     0.1,
 				"taskmanager.network.request-backoff.max": 5000,
 				"jobmanager.rpc.address":                  "wrong-address",
+				"env.java.opts.jobmanager": "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=39000 -XX:+UseG1GC",
 			},
 			TaskManagerConfig: v1beta1.TaskManagerConfig{
 				TaskSlots:             &taskSlots,
@@ -53,6 +54,7 @@ func TestRenderFlinkConfigOverrides(t *testing.T) {
 	expected := []string{
 		"akka.timeout: 5s",
 		fmt.Sprintf("blob.server.port: %d", blobPort),
+		"env.java.opts.jobmanager: -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=39000 -XX:+UseG1GC",
 		"jobmanager.heap.size: 1536", // defaults
 		fmt.Sprintf("jobmanager.rpc.port: %d", RPCDefaultPort),
 		fmt.Sprintf("jobmanager.web.port: %d", UIDefaultPort),

--- a/pkg/controller/flink/config_test.go
+++ b/pkg/controller/flink/config_test.go
@@ -28,7 +28,7 @@ func TestRenderFlinkConfigOverrides(t *testing.T) {
 				"taskmanager.network.memory.fraction":     0.1,
 				"taskmanager.network.request-backoff.max": 5000,
 				"jobmanager.rpc.address":                  "wrong-address",
-				"env.java.opts.jobmanager": "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=39000 -XX:+UseG1GC",
+				"env.java.opts.jobmanager":                "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=39000 -XX:+UseG1GC",
 			},
 			TaskManagerConfig: v1beta1.TaskManagerConfig{
 				TaskSlots:             &taskSlots,


### PR DESCRIPTION
Flink's config format looks like YAML, but is not _really_ YAML. The [parser](https://github.com/apache/flink/blob/9e6ff81e22d6f5f04abb50ca1aea84fd2542bf9d/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java#L181) is extremely simple, and basically operates just by splitting each line on  `: ` and treating the first part as a key and the second as the value.

Currently we are using gopkg.in/yaml.v2 to render the config. However, this breaks in the case of long strings with spaces (like 
```
-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=39000 -XX:+UseG1GC
```
). In that case, yaml.v2 will convert the space into a line break (https://github.com/go-yaml/yaml/issues/166), producing output like

```yaml
env.java.opts.jobmanager: -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=39000
  -XX:+UseG1GC
```

This _is_ valid YAML,  but cannot be handled by flink's simple parser.

This PR fixes the issue by doing the printing ourselves. As flink only supports simple key-value pairs in its config, this is pretty straightforward and more correct than using a real YAML library.

**This is an incompatible change for apps that have a long, space-separated config**



