### PR TITLE
Add Web UI information to status

### DIFF
--- a/pkg/apis/app/v1alpha1/types.go
+++ b/pkg/apis/app/v1alpha1/types.go
@@ -127,7 +127,6 @@ type SavepointInfo struct {
 }
 
 type FlinkClusterStatus struct {
-	ClusterOverviewURL   string       `json:"clusterOverviewURL,omitEmpty"`
 	Health               HealthStatus `json:"health,omitempty"`
 	NumberOfTaskManagers int32        `json:"numberOfTaskManagers,omitempty"`
 	HealthyTaskManagers  int32        `json:"healthyTaskManagers,omitepty"`
@@ -136,10 +135,9 @@ type FlinkClusterStatus struct {
 }
 
 type FlinkJobStatus struct {
-	JobOverviewURL string       `json:"jobOverviewURL,omitEmpty"`
-	JobID          string       `json:"jobID,omitEmpty"`
-	Health         HealthStatus `json:"health,omitEmpty"`
-	State          JobState     `json:"state,omitEmpty"`
+	JobID  string       `json:"jobID,omitEmpty"`
+	Health HealthStatus `json:"health,omitEmpty"`
+	State  JobState     `json:"state,omitEmpty"`
 
 	JarName               string `json:"jarName"`
 	Parallelism           int32  `json:"parallelism"`

--- a/pkg/apis/app/v1alpha1/types.go
+++ b/pkg/apis/app/v1alpha1/types.go
@@ -127,6 +127,7 @@ type SavepointInfo struct {
 }
 
 type FlinkClusterStatus struct {
+	ClusterOverviewURL   string       `json:"clusterOverviewURL,omitEmpty"`
 	Health               HealthStatus `json:"health,omitempty"`
 	NumberOfTaskManagers int32        `json:"numberOfTaskManagers,omitempty"`
 	HealthyTaskManagers  int32        `json:"healthyTaskManagers,omitepty"`
@@ -135,9 +136,10 @@ type FlinkClusterStatus struct {
 }
 
 type FlinkJobStatus struct {
-	JobID  string       `json:"jobID,omitEmpty"`
-	Health HealthStatus `json:"health,omitEmpty"`
-	State  JobState     `json:"state,omitEmpty"`
+	JobOverviewURL string       `json:"jobOverviewURL,omitEmpty"`
+	JobID          string       `json:"jobID,omitEmpty"`
+	Health         HealthStatus `json:"health,omitEmpty"`
+	State          JobState     `json:"state,omitEmpty"`
 
 	JarName               string `json:"jarName"`
 	Parallelism           int32  `json:"parallelism"`

--- a/pkg/apis/app/v1beta1/types.go
+++ b/pkg/apis/app/v1beta1/types.go
@@ -127,6 +127,7 @@ type SavepointInfo struct {
 }
 
 type FlinkClusterStatus struct {
+	ClusterOverviewURL   string       `json:"clusterOverviewURL,omitempty"`
 	Health               HealthStatus `json:"health,omitempty"`
 	NumberOfTaskManagers int32        `json:"numberOfTaskManagers,omitempty"`
 	HealthyTaskManagers  int32        `json:"healthyTaskManagers,omitepty"`
@@ -135,9 +136,10 @@ type FlinkClusterStatus struct {
 }
 
 type FlinkJobStatus struct {
-	JobID  string       `json:"jobID,omitEmpty"`
-	Health HealthStatus `json:"health,omitEmpty"`
-	State  JobState     `json:"state,omitEmpty"`
+	JobOverviewURL string       `json:"jobOverviewURL,omitempty"`
+	JobID          string       `json:"jobID,omitEmpty"`
+	Health         HealthStatus `json:"health,omitEmpty"`
+	State          JobState     `json:"state,omitEmpty"`
 
 	JarName               string `json:"jarName"`
 	Parallelism           int32  `json:"parallelism"`

--- a/pkg/controller/flink/client/api.go
+++ b/pkg/controller/flink/client/api.go
@@ -16,14 +16,16 @@ import (
 	"github.com/pkg/errors"
 )
 
+const GetJobsOverviewURL = "/jobs/%s"
+const GetClusterOverviewURL = "/overview"
+const WebUIAnchor = "/#"
+
 const submitJobURL = "/jars/%s/run"
 const savepointURL = "/jobs/%s/savepoints"
 const jobURL = "/jobs/%s"
 const checkSavepointStatusURL = "/jobs/%s/savepoints/%s"
 const getJobsURL = "/jobs"
-const getJobsOverviewURL = "/jobs/%s"
 const getJobConfigURL = "/jobs/%s/config"
-const getOverviewURL = "/overview"
 const checkpointsURL = "/jobs/%s/checkpoints"
 const taskmanagersURL = "/taskmanagers"
 const httpGet = "GET"
@@ -119,7 +121,7 @@ func (c *FlinkJobManagerClient) GetJobConfig(ctx context.Context, url, jobID str
 }
 
 func (c *FlinkJobManagerClient) GetClusterOverview(ctx context.Context, url string) (*ClusterOverviewResponse, error) {
-	url = url + getOverviewURL
+	url = url + GetClusterOverviewURL
 	response, err := c.executeRequest(ctx, httpGet, url, nil)
 	if err != nil {
 		c.metrics.getClusterFailureCounter.Inc(ctx)
@@ -347,7 +349,7 @@ func (c *FlinkJobManagerClient) GetCheckpointCounts(ctx context.Context, url str
 }
 
 func (c *FlinkJobManagerClient) GetJobOverview(ctx context.Context, url string, jobID string) (*FlinkJobOverview, error) {
-	endpoint := fmt.Sprintf(url+getJobsOverviewURL, jobID)
+	endpoint := fmt.Sprintf(url+GetJobsOverviewURL, jobID)
 	response, err := c.executeRequest(ctx, httpGet, endpoint, nil)
 	if err != nil {
 		return nil, GetRetryableError(err, GetJobOverview, GlobalFailure, DefaultRetries)

--- a/pkg/controller/flink/flink.go
+++ b/pkg/controller/flink/flink.go
@@ -140,12 +140,13 @@ func getURLFromApp(application *v1beta1.FlinkApplication, hash string) string {
 	return fmt.Sprintf("http://%s.%s:%d", service, application.Namespace, port)
 }
 
-func getGenericURLFromApp(application *v1beta1.FlinkApplication) string {
+func getExternalURLFromApp(application *v1beta1.FlinkApplication) string {
 	cfg := controllerConfig.GetConfig()
+	// Local environment
 	if cfg.UseProxy {
 		return fmt.Sprintf(proxyURL, cfg.ProxyPort.Port, application.Namespace, application.Name)
 	}
-	return fmt.Sprintf("http://%s.%s:%d", application.Name, application.Namespace, port)
+	return GetFlinkUIIngressURL(application.Name)
 }
 
 func GetActiveFlinkJob(jobs []client.FlinkJob) *client.FlinkJob {
@@ -441,7 +442,7 @@ func (f *Controller) CompareAndUpdateClusterStatus(ctx context.Context, applicat
 	if deployment == nil || err != nil {
 		return false, err
 	}
-	application.Status.ClusterStatus.ClusterOverviewURL = fmt.Sprintf(getGenericURLFromApp(application) + client.WebUIAnchor + client.GetClusterOverviewURL)
+	application.Status.ClusterStatus.ClusterOverviewURL = fmt.Sprintf(getExternalURLFromApp(application) + client.WebUIAnchor + client.GetClusterOverviewURL)
 	application.Status.ClusterStatus.NumberOfTaskManagers = deployment.Taskmanager.Status.AvailableReplicas
 	// Get Cluster overview
 	response, err := f.flinkClient.GetClusterOverview(ctx, getURLFromApp(application, hash))
@@ -503,7 +504,7 @@ func (f *Controller) CompareAndUpdateJobStatus(ctx context.Context, app *v1beta1
 	}
 
 	// Job status
-	app.Status.JobStatus.JobOverviewURL = fmt.Sprintf(getGenericURLFromApp(app)+client.WebUIAnchor+client.GetJobsOverviewURL, app.Status.JobStatus.JobID)
+	app.Status.JobStatus.JobOverviewURL = fmt.Sprintf(getExternalURLFromApp(app)+client.WebUIAnchor+client.GetJobsOverviewURL, app.Status.JobStatus.JobID)
 	app.Status.JobStatus.State = v1beta1.JobState(jobResponse.State)
 	jobStartTime := metav1.NewTime(time.Unix(jobResponse.StartTime/1000, 0))
 	app.Status.JobStatus.StartTime = &jobStartTime

--- a/pkg/controller/flink/flink_test.go
+++ b/pkg/controller/flink/flink_test.go
@@ -635,6 +635,7 @@ func TestClusterStatusUpdated(t *testing.T) {
 	assert.Equal(t, int32(0), flinkApp.Status.ClusterStatus.AvailableTaskSlots)
 	assert.Equal(t, int32(1), flinkApp.Status.ClusterStatus.HealthyTaskManagers)
 	assert.Equal(t, v1beta1.Green, flinkApp.Status.ClusterStatus.Health)
+	assert.Equal(t, "http://app-name.ns:8081/#/overview", flinkApp.Status.ClusterStatus.ClusterOverviewURL)
 
 }
 
@@ -791,6 +792,7 @@ func TestJobStatusUpdated(t *testing.T) {
 	assert.Equal(t, &expectedTime, flinkApp.Status.JobStatus.RestoreTime)
 	assert.Equal(t, "/test/externalpath", flinkApp.Status.JobStatus.RestorePath)
 	assert.Equal(t, &expectedTime, flinkApp.Status.JobStatus.LastCheckpointTime)
+	assert.Equal(t, "http://app-name.ns:8081/#/jobs/abc", flinkApp.Status.JobStatus.JobOverviewURL)
 
 }
 
@@ -810,6 +812,7 @@ func TestNoJobStatusChange(t *testing.T) {
 	app1.Status.JobStatus.Health = v1beta1.Green
 	app1.Status.JobStatus.RestoreTime = &metaTime
 	app1.Status.JobStatus.RestorePath = "/test/externalpath"
+	app1.Status.JobStatus.JobOverviewURL = "http://app-name.ns:8081/#/jobs/j1"
 
 	mockJmClient.GetJobOverviewFunc = func(ctx context.Context, url string, jobID string) (*client.FlinkJobOverview, error) {
 		assert.Equal(t, url, "http://app-name-hash.ns:8081")

--- a/pkg/controller/flink/flink_test.go
+++ b/pkg/controller/flink/flink_test.go
@@ -635,7 +635,7 @@ func TestClusterStatusUpdated(t *testing.T) {
 	assert.Equal(t, int32(0), flinkApp.Status.ClusterStatus.AvailableTaskSlots)
 	assert.Equal(t, int32(1), flinkApp.Status.ClusterStatus.HealthyTaskManagers)
 	assert.Equal(t, v1beta1.Green, flinkApp.Status.ClusterStatus.Health)
-	assert.Equal(t, "http://app-name.ns:8081/#/overview", flinkApp.Status.ClusterStatus.ClusterOverviewURL)
+	assert.Equal(t, "/#/overview", flinkApp.Status.ClusterStatus.ClusterOverviewURL)
 
 }
 
@@ -792,7 +792,7 @@ func TestJobStatusUpdated(t *testing.T) {
 	assert.Equal(t, &expectedTime, flinkApp.Status.JobStatus.RestoreTime)
 	assert.Equal(t, "/test/externalpath", flinkApp.Status.JobStatus.RestorePath)
 	assert.Equal(t, &expectedTime, flinkApp.Status.JobStatus.LastCheckpointTime)
-	assert.Equal(t, "http://app-name.ns:8081/#/jobs/abc", flinkApp.Status.JobStatus.JobOverviewURL)
+	assert.Equal(t, "/#/jobs/abc", flinkApp.Status.JobStatus.JobOverviewURL)
 
 }
 
@@ -812,7 +812,7 @@ func TestNoJobStatusChange(t *testing.T) {
 	app1.Status.JobStatus.Health = v1beta1.Green
 	app1.Status.JobStatus.RestoreTime = &metaTime
 	app1.Status.JobStatus.RestorePath = "/test/externalpath"
-	app1.Status.JobStatus.JobOverviewURL = "http://app-name.ns:8081/#/jobs/j1"
+	app1.Status.JobStatus.JobOverviewURL = "/#/jobs/j1"
 
 	mockJmClient.GetJobOverviewFunc = func(ctx context.Context, url string, jobID string) (*client.FlinkJobOverview, error) {
 		assert.Equal(t, url, "http://app-name-hash.ns:8081")


### PR DESCRIPTION
This PR adds the cluster and job overview URLs to the cluster and job status respectively. The objective is to provide users easy access to the required Web UI. This information can also be used in any other CI/D tooling used to support Flink applications on k8s.  

Example output:
```yaml
Status:
  Cluster Status:
    Available Task Slots:     1
    Cluster Overview URL:     http://localhost:8001/api/v1/namespaces/default/services/simpleflinkk8s:8081/proxy/#/overview
    Health:                   Green
    Healthy Task Managers:    1
    Number Of Task Managers:  1
    Number Of Task Slots:     2
  Deploy Hash:                18051096
  Failed Deploy Hash:
  Job Status:
    Completed Checkpoint Count:  10
    Entry Class:                 com.lyft.OperatorTestApp
    Failed Checkpoint Count:     0
    Health:                      Green
    Jar Name:                    operator-test-app-1.0.0-SNAPSHOT.jar
    Job ID:                      c669950ee11c64980180eeaf9e62a63f
    Job Overview URL:            http://localhost:8001/api/v1/namespaces/default/services/simpleflinkk8s:8081/proxy/#/jobs/c669950ee11c64980180eeaf9e62a63f
    Job Restart Count:           0
```