### PR TITLE
[STRMCMP-611] Log events for all rollback situations

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -961,7 +961,6 @@
     "github.com/spf13/pflag",
     "github.com/stretchr/testify/assert",
     "gopkg.in/check.v1",
-    "gopkg.in/yaml.v2",
     "k8s.io/api/apps/v1",
     "k8s.io/api/core/v1",
     "k8s.io/api/extensions/v1beta1",

--- a/pkg/controller/flinkapplication/flink_state_machine_test.go
+++ b/pkg/controller/flinkapplication/flink_state_machine_test.go
@@ -635,7 +635,8 @@ func TestIsApplicationStuck(t *testing.T) {
 		return ferr.IsFailFast
 	}
 	// Retryable error
-	assert.False(t, stateMachineForTest.shouldRollback(context.Background(), app))
+	shouldRollback, _ := stateMachineForTest.shouldRollback(context.Background(), app)
+	assert.False(t, shouldRollback)
 	// Retryable errors don't get reset until all retries are exhausted
 	assert.NotNil(t, app.Status.LastSeenError)
 	// the rollback loop does not update retry counts.
@@ -644,14 +645,16 @@ func TestIsApplicationStuck(t *testing.T) {
 	// Retryable error with retries exhausted
 	app.Status.RetryCount = 100
 	app.Status.LastSeenError = retryableErr.(*client.FlinkApplicationError)
-	assert.True(t, stateMachineForTest.shouldRollback(context.Background(), app))
+	shouldRollback, _ = stateMachineForTest.shouldRollback(context.Background(), app)
+	assert.True(t, shouldRollback, app)
 	assert.Nil(t, app.Status.LastSeenError)
 	assert.Equal(t, int32(100), app.Status.RetryCount)
 
 	// Fail fast error
 	app.Status.RetryCount = 0
 	app.Status.LastSeenError = failFastError.(*client.FlinkApplicationError)
-	assert.True(t, stateMachineForTest.shouldRollback(context.Background(), app))
+	shouldRollback, _ = stateMachineForTest.shouldRollback(context.Background(), app)
+	assert.True(t, shouldRollback)
 	assert.Nil(t, app.Status.LastSeenError)
 	assert.Equal(t, int32(0), app.Status.RetryCount)
 


### PR DESCRIPTION
Currently certain rollback triggers (like the default time-based one) do not report anything back to the user about _why_ the deploy was rolled-back. For example:

```
  Normal   CreatingCluster   12m    flinkK8sOperator  Creating Flink cluster for deploy fe5e6e29
  Warning  RolledBackDeploy  6m50s  flinkK8sOperator  Successfull rolled back deploy fe5e6e29
  Normal   ToreDownCluster   6m50s  flinkK8sOperator  Deleted old cluster with hash fe5e6e29
```

From the events it looks like everything was fine, until the operator randomly decided to roll back.

This PR ensures that we also log a reason for the rollback.
