### PR TITLE
[STRMCMP-616] Use error retrying system for savepoint errors during deletion

### DIFF
--- a/integ/test.sh
+++ b/integ/test.sh
@@ -9,5 +9,5 @@ export OPERATOR_IMAGE=127.0.0.1:32000/flinkk8soperator:local
 umask 000
 
 cd $(dirname "$0")
-go test -timeout 22m -check.vv IntegSuite
+go test -timeout 30m -check.vv IntegSuite
 

--- a/integ/utils/utils.go
+++ b/integ/utils/utils.go
@@ -139,7 +139,7 @@ func (f *TestUtil) CreateCRD() error {
 
 func (f *TestUtil) CreateOperator() error {
 	configValue := make(map[string]string)
-	configValue["development"] = "operator:\n  containerNameFormat: \"%s-unknown\"\n  resyncPeriod: 5s\n  baseBackoffDuration: 10ms\n  maxBackoffDuration: 50ms\n  maxErrDuration: 40s\n "
+	configValue["development"] = "operator:\n  containerNameFormat: \"%s-unknown\"\n  resyncPeriod: 5s\n  baseBackoffDuration: 50ms\n  maxBackoffDuration: 2s\n  maxErrDuration: 40s\n "
 
 	configMap := v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -2,6 +2,7 @@ package flinkapplication
 
 import (
 	"context"
+	"math"
 	"time"
 
 	"k8s.io/client-go/tools/record"
@@ -676,6 +677,8 @@ func (s *FlinkStateMachine) handleApplicationDeleting(ctx context.Context, app *
 					fmt.Sprintf("Failed to take savepoint %v", status.Operation.FailureCause))
 				// clear the trigger id so that we can try again
 				app.Spec.SavepointInfo.TriggerID = ""
+				return true, client.GetRetryableError(errors.New("failed to take savepoint"),
+					client.CancelJobWithSavepoint, "500", math.MaxInt32)
 			} else if status.SavepointStatus.Status == client.SavePointCompleted {
 				// we're done, clean up
 				s.flinkController.LogEvent(ctx, app, corev1.EventTypeNormal, "CanceledJob",

--- a/pkg/controller/flinkapplication/flink_state_machine_test.go
+++ b/pkg/controller/flinkapplication/flink_state_machine_test.go
@@ -730,21 +730,20 @@ func TestDeleteWithSavepoint(t *testing.T) {
 				},
 				Operation: client.SavepointOperationResponse{
 					FailureCause: client.FailureCause{
-						Class: "java.util.concurrent.CompletionException",
+						Class:      "java.util.concurrent.CompletionException",
 						StackTrace: "Exception",
 					},
 				},
 			}, nil
-		} else {
-			return &client.SavepointResponse{
-				SavepointStatus: client.SavepointStatusResponse{
-					Status: client.SavePointCompleted,
-				},
-				Operation: client.SavepointOperationResponse{
-					Location: "s3:///path/to/savepoint",
-				},
-			}, nil
 		}
+		return &client.SavepointResponse{
+			SavepointStatus: client.SavepointStatusResponse{
+				Status: client.SavePointCompleted,
+			},
+			Operation: client.SavepointOperationResponse{
+				Location: "s3:///path/to/savepoint",
+			},
+		}, nil
 	}
 
 	// the first time we return an error from the savepointing status

--- a/pkg/controller/flinkapplication/flink_state_machine_test.go
+++ b/pkg/controller/flinkapplication/flink_state_machine_test.go
@@ -704,8 +704,10 @@ func TestDeleteWithSavepoint(t *testing.T) {
 		if updateCount == 1 {
 			assert.Equal(t, triggerID, application.Spec.SavepointInfo.TriggerID)
 		} else if updateCount == 2 {
-			assert.Equal(t, savepointPath, application.Spec.SavepointInfo.SavepointLocation)
+			assert.NotNil(t, application.Status.LastSeenError)
 		} else if updateCount == 3 {
+			assert.Equal(t, savepointPath, application.Spec.SavepointInfo.SavepointLocation)
+		} else if updateCount == 4 {
 			assert.Equal(t, 0, len(app.Finalizers))
 		}
 
@@ -717,21 +719,42 @@ func TestDeleteWithSavepoint(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 2, updateCount)
 
+	savepointStatusCount := 0
 	mockFlinkController.GetSavepointStatusFunc = func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (*client.SavepointResponse, error) {
-		return &client.SavepointResponse{
-			SavepointStatus: client.SavepointStatusResponse{
-				Status: client.SavePointCompleted,
-			},
-			Operation: client.SavepointOperationResponse{
-				Location: "s3:///path/to/savepoint",
-			},
-		}, nil
+		savepointStatusCount++
+
+		if savepointStatusCount == 1 {
+			return &client.SavepointResponse{
+				SavepointStatus: client.SavepointStatusResponse{
+					Status: client.SavePointCompleted,
+				},
+				Operation: client.SavepointOperationResponse{
+					FailureCause: client.FailureCause{
+						Class: "java.util.concurrent.CompletionException",
+						StackTrace: "Exception",
+					},
+				},
+			}, nil
+		} else {
+			return &client.SavepointResponse{
+				SavepointStatus: client.SavepointStatusResponse{
+					Status: client.SavePointCompleted,
+				},
+				Operation: client.SavepointOperationResponse{
+					Location: "s3:///path/to/savepoint",
+				},
+			}, nil
+		}
 	}
+
+	// the first time we return an error from the savepointing status
+	err = stateMachineForTest.Handle(context.Background(), app.DeepCopy())
+	assert.Error(t, err)
 
 	err = stateMachineForTest.Handle(context.Background(), &app)
 	assert.NoError(t, err)
 
-	assert.Equal(t, 3, updateCount)
+	assert.Equal(t, 4, updateCount)
 
 	mockFlinkController.GetJobsForApplicationFunc = func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (jobs []client.FlinkJob, err error) {
 		return []client.FlinkJob{
@@ -745,7 +768,7 @@ func TestDeleteWithSavepoint(t *testing.T) {
 	err = stateMachineForTest.Handle(context.Background(), &app)
 	assert.NoError(t, err)
 
-	assert.Equal(t, 4, updateCount)
+	assert.Equal(t, 5, updateCount)
 
 }
 


### PR DESCRIPTION
Currently, if a flinkapplication is being deleted with `DeleteMode: Savepoint` and the savepoint operation is failing, we will retry endlessly with no delay on the savepoint operation. This is because in that case, we don't return an error back to the error management system of the state machine.

This PR fixes that by properly returning an error for that situation. This causes us to do retry with exponential backoff instead of on every statemachine iteration.

It also should fix the "exceeded the maximum log length" integration test failures, which are caused by endless logging of the retries.