### PR TITLE
Upgrade to Controller Runtime v0.2.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -895,7 +895,7 @@
   revision = "c55fbcfc754a5b2ec2fbae8fb9dcac36bdba6a12"
 
 [[projects]]
-  digest = "1:5c7f9edbc373a776ffbe574b59d6df3827dff78a11151d045615f799df38a010"
+  digest = "1:4bd3324a3d2244bbc74f82d352e97af5df6f808afcb6b15f0dd181cff3051400"
   name = "sigs.k8s.io/controller-runtime"
   packages = [
     "pkg/cache",
@@ -927,8 +927,8 @@
     "pkg/webhook/internal/metrics",
   ]
   pruneopts = ""
-  revision = "aaddbd9d9a89d8ff329a084aece23be0406e6467"
-  version = "v0.2.0-beta.4"
+  revision = "e1159d6655b260c4812fd0792cd1344ecc96a57e"
+  version = "v0.2.0"
 
 [[projects]]
   digest = "1:321081b4a44256715f2b68411d8eda9a17f17ebfe6f0cc61d2cc52d11c08acfa"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -16,7 +16,7 @@ required = [
 
 [[constraint]]
   name = "sigs.k8s.io/controller-runtime"
-  version = "v0.2.0-beta.3"
+  version = "v0.2.0"
 
 [[override]]
   name = "k8s.io/api"

--- a/pkg/controller/k8/cluster.go
+++ b/pkg/controller/k8/cluster.go
@@ -117,15 +117,15 @@ func (k *Cluster) GetDeploymentsWithLabel(ctx context.Context, namespace string,
 	}
 
 	namespaceOpt := client.InNamespace(namespace)
-	matchField := client.MatchingFields(labelMap)
-	err := k.cache.List(ctx, deploymentList, namespaceOpt, matchField)
+	matchLabel := client.MatchingLabels(labelMap)
+	err := k.cache.List(ctx, deploymentList, namespaceOpt, matchLabel)
 	if err == nil {
 		k.metrics.getDeploymentCacheHit.Inc(ctx)
 		return deploymentList, nil
 	}
 	if IsK8sObjectDoesNotExist(err) {
 		k.metrics.getDeploymentCacheMiss.Inc(ctx)
-		err := k.client.List(ctx, deploymentList, namespaceOpt, matchField)
+		err := k.client.List(ctx, deploymentList, namespaceOpt, matchLabel)
 		if err != nil {
 			k.metrics.getDeploymentFailure.Inc(ctx)
 			logger.Warnf(ctx, "Failed to list deployments %v", err)
@@ -145,12 +145,12 @@ func (k *Cluster) GetServicesWithLabel(ctx context.Context, namespace string, la
 		},
 	}
 	namespaceOpt := client.InNamespace(namespace)
-	matchField := client.MatchingFields(labelMap)
+	matchLabel := client.MatchingLabels(labelMap)
 
-	err := k.cache.List(ctx, serviceList, namespaceOpt, matchField)
+	err := k.cache.List(ctx, serviceList, namespaceOpt, matchLabel)
 	if err != nil {
 		if IsK8sObjectDoesNotExist(err) {
-			err := k.client.List(ctx, serviceList, namespaceOpt, matchField)
+			err := k.client.List(ctx, serviceList, namespaceOpt, matchLabel)
 			if err != nil {
 				logger.Warnf(ctx, "Failed to list services %v", err)
 				return nil, err


### PR DESCRIPTION
Upgrades the controller runtime library from `v0.2.0-beta.3` to `v0.2.0`.

cc @yuchaoran2011 - https://github.com/lyft/flinkk8soperator/issues/93