### PR TITLE
[STRMCMP-569] Failures during job startup should trigger immediate rollback

### DIFF
--- a/pkg/controller/flink/client/error_handler.go
+++ b/pkg/controller/flink/client/error_handler.go
@@ -21,22 +21,31 @@ const (
 	NoRetries          = 0
 )
 
-func GetRetryableError(err error, method v1beta1.FlinkMethod, errorCode string, maxRetries int32, message ...string) error {
+func GetRetryableError(err error, method v1beta1.FlinkMethod, errorCode string, maxRetries int32) error {
+	return GetRetryableErrorWithMessage(err, method, errorCode, maxRetries, "")
+}
+
+func GetRetryableErrorWithMessage(err error, method v1beta1.FlinkMethod, errorCode string, maxRetries int32, message string) error {
 	appError := getErrorValue(err, method, errorCode, message)
 	return NewFlinkApplicationError(appError.Error(), method, errorCode, true, false, maxRetries)
 }
 
-func GetNonRetryableError(err error, method v1beta1.FlinkMethod, errorCode string, message ...string) error {
+func GetNonRetryableError(err error, method v1beta1.FlinkMethod, errorCode string) error {
+	return GetNonRetryableErrorWithMessage(err, method, errorCode, "")
+}
+
+func GetNonRetryableErrorWithMessage(err error, method v1beta1.FlinkMethod, errorCode string, message string) error {
 	appError := getErrorValue(err, method, errorCode, message)
 	return NewFlinkApplicationError(appError.Error(), method, errorCode, false, true, NoRetries)
 }
 
-func getErrorValue(err error, method v1beta1.FlinkMethod, errorCode string, message []string) error {
+func getErrorValue(err error, method v1beta1.FlinkMethod, errorCode string, message string) error {
 	if err == nil {
-		return errors.New(fmt.Sprintf("%v call failed with status %v and message %v", method, errorCode, message))
+		return errors.New(fmt.Sprintf("%v call failed with status %v and message '%s'", method, errorCode, message))
 	}
-	return errors.Wrapf(err, "%v call failed with status %v and message %v", method, errorCode, message)
+	return errors.Wrapf(err, "%v call failed with status %v and message '%s'", method, errorCode, message)
 }
+
 func min(a, b int) int {
 	if a < b {
 		return a

--- a/pkg/controller/flink/client/error_handler_test.go
+++ b/pkg/controller/flink/client/error_handler_test.go
@@ -18,19 +18,19 @@ func getTestRetryer() RetryHandler {
 func TestGetError(t *testing.T) {
 	testErr := errors.New("Service unavailable")
 	ferr := GetNonRetryableError(testErr, "GetTest", "500")
-	assert.Equal(t, "GetTest call failed with status 500 and message []: Service unavailable", ferr.Error())
+	assert.Equal(t, "GetTest call failed with status 500 and message '': Service unavailable", ferr.Error())
 
 	//nil error
 	ferrNil := GetNonRetryableError(nil, "GetTest", "500")
-	assert.Equal(t, "GetTest call failed with status 500 and message []", ferrNil.Error())
+	assert.Equal(t, "GetTest call failed with status 500 and message ''", ferrNil.Error())
 
 	testWrappedErr := errors.Wrap(testErr, "Wrapped errors")
 	ferrWrapped := GetNonRetryableError(testWrappedErr, "GetTestWrapped", "400")
-	assert.Equal(t, "GetTestWrapped call failed with status 400 and message []: Wrapped errors: Service unavailable", ferrWrapped.Error())
+	assert.Equal(t, "GetTestWrapped call failed with status 400 and message '': Wrapped errors: Service unavailable", ferrWrapped.Error())
 
 	testMessageErr := errors.New("Test Error")
-	ferrMessage := GetNonRetryableError(testMessageErr, "GetTest", "500", "message1", "message2")
-	assert.Equal(t, "GetTest call failed with status 500 and message [message1 message2]: Test Error", ferrMessage.Error())
+	ferrMessage := GetNonRetryableErrorWithMessage(testMessageErr, "GetTest", "500", "message")
+	assert.Equal(t, "GetTest call failed with status 500 and message 'message': Test Error", ferrMessage.Error())
 }
 
 func TestErrors(t *testing.T) {


### PR DESCRIPTION
When the user specifies a wrong entry class or the main method throws an exception, the Flink API returns back a 500 error with a `org.apache.flink.client.program.ProgramInvocationException`.

In order to minimize downtime, we want to rollback immediately in this case rather than waiting for retries to be exhausted.

This PR also improves the error reporting a bit for this situation. Previously, the error wrapping functions took an array of strings which were reported verbatim. This produced confusing output that implied that the API itself was returning an array. As all actual calls to these methods were using either 0 or 1 arguments, I've split it out into those particular cases.