### PR TITLE
Keep config names constant across error_handler and config

### DIFF
--- a/pkg/controller/flink/client/error_handler.go
+++ b/pkg/controller/flink/client/error_handler.go
@@ -64,7 +64,7 @@ type RetryHandlerInterface interface {
 // A Retryer that has methods to determine if an error is retryable and also does exponential backoff
 type RetryHandler struct {
 	baseBackOffDuration      time.Duration
-	maxErrWaitDuration       time.Duration
+	maxErrDuration           time.Duration
 	maxBackOffMillisDuration time.Duration
 }
 
@@ -95,7 +95,7 @@ func (r RetryHandler) IsRetryRemaining(err error, retryCount int32) bool {
 
 func (r RetryHandler) WaitOnError(clock clock.Clock, lastUpdatedTime time.Time) (time.Duration, bool) {
 	elapsedTime := clock.Since(lastUpdatedTime)
-	return elapsedTime, elapsedTime <= r.maxErrWaitDuration
+	return elapsedTime, elapsedTime <= r.maxErrDuration
 
 }
 func (r RetryHandler) GetRetryDelay(retryCount int32) time.Duration {


### PR DESCRIPTION
This PR updates the field name in error_handler.go to be consistent with the one defined in config.go https://github.com/lyft/flinkk8soperator/blob/master/pkg/controller/config/config.go#L26