### PR TITLE
[#97] [STRMCMP-648] [BREAKING] Fix rendering of flink memory configs

### DIFF
--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -97,6 +97,8 @@ spec:
                   minimum: 1
                 offHeapMemoryFraction:
                   type: number
+                  minimum: 0
+                  maximum: 1
                 nodeSelector:
                   type: object
                   properties:
@@ -222,6 +224,8 @@ spec:
                   minimum: 1
                 offHeapMemoryFraction:
                   type: number
+                  minimum: 0
+                  maximum: 1
                 nodeSelector:
                   type: object
                   properties:

--- a/docs/crd.md
+++ b/docs/crd.md
@@ -34,7 +34,9 @@ Below is the list of fields in the custom resource and their description
 
     * **offHeapMemoryFraction** `type:float64`
       A value between 0 and 1 that represents % of container memory dedicated to system / off heap. The
-      remaining memory is allocated for heap.
+      remaining memory is given to the taskmanager. Note that Flink may further reserve some of this
+      memory for off-heap uses like network buffers, so you may see the JVM heap size configured to
+      a lower amount.
 
     * **nodeSelector** `type:map[string]string`
       Configuration for the node selectors used for the task manager
@@ -108,7 +110,7 @@ Below is the list of fields in the custom resource and their description
   * **volumeMounts** `type:[]v1.VolumeMount`
     Describes a mounting of a Volume within a container.
     
-  * **ForceRollback** `type:bool`
+  * **forceRollback** `type:bool`
     Can be set to true to force rollback a deploy/update. The rollback is **not** performed when the application is in a **RUNNING** phase.
     If an application is successfully rolled back, it is moved to a *DeployFailed* phase. Un-setting or setting `ForceRollback` to `False` will allow updates to progress normally.
     

--- a/integ/test_app.yaml
+++ b/integ/test_app.yaml
@@ -14,6 +14,7 @@ spec:
     state.checkpoints.dir: file:///checkpoints/flink/externalized-checkpoints
     state.savepoints.dir: file:///checkpoints/flink/savepoints
   jobManagerConfig:
+    offHeapMemoryFraction: 0.2
     resources:
       requests:
         memory: "200Mi"
@@ -21,6 +22,7 @@ spec:
     replicas: 1
   taskManagerConfig:
     taskSlots: 2
+    offHeapMemoryFraction: 0.5
     resources:
       requests:
         memory: "400Mi"

--- a/pkg/controller/flink/flink_test.go
+++ b/pkg/controller/flink/flink_test.go
@@ -31,7 +31,7 @@ import (
 const testImage = "123.xyz.com/xx:11ae1218924428faabd9b64423fa0c332efba6b2"
 
 // Note: if you find yourself changing this to fix a test, that should be treated as a breaking API change
-const testAppHash = "c503e97e"
+const testAppHash = "8c2d576f"
 const testAppName = "app-name"
 const testNamespace = "ns"
 const testJobID = "j1"

--- a/pkg/controller/flink/job_manager_controller_test.go
+++ b/pkg/controller/flink/job_manager_controller_test.go
@@ -59,7 +59,7 @@ func TestJobManagerCreateSuccess(t *testing.T) {
 		"flink-job-properties": "jarName: " + testJarName + "\nparallelism: 8\nentryClass:" + testEntryClass + "\nprogramArgs:\"" + testProgramArgs + "\"",
 	}
 	app.Annotations = annotations
-	hash := "d62c9c38"
+	hash := "3b2fc68e"
 	expectedLabels := map[string]string{
 		"flink-app":             "app-name",
 		"flink-app-hash":        hash,
@@ -84,10 +84,10 @@ func TestJobManagerCreateSuccess(t *testing.T) {
 			assert.Equal(t, "flink.k8s.io/v1beta1", deployment.OwnerReferences[0].APIVersion)
 			assert.Equal(t, "FlinkApplication", deployment.OwnerReferences[0].Kind)
 
-			assert.Equal(t, "blob.server.port: 6125\njobmanager.heap.size: 1536\n"+
+			assert.Equal(t, "blob.server.port: 6125\njobmanager.heap.size: 1572864k\n"+
 				"jobmanager.rpc.port: 6123\n"+
 				"jobmanager.web.port: 8081\nmetrics.internal.query-service.port: 50101\n"+
-				"query.server.port: 6124\ntaskmanager.heap.size: 512\n"+
+				"query.server.port: 6124\ntaskmanager.heap.size: 524288k\n"+
 				"taskmanager.numberOfTaskSlots: 16\n\n"+
 				"jobmanager.rpc.address: app-name-"+hash+"\n",
 				common.GetEnvVar(deployment.Spec.Template.Spec.Containers[0].Env,
@@ -136,7 +136,7 @@ func TestJobManagerHACreateSuccess(t *testing.T) {
 	app.Spec.FlinkConfig = map[string]interface{}{
 		"high-availability": "zookeeper",
 	}
-	hash := "063e33b7"
+	hash := "4a2f1a08"
 	expectedLabels := map[string]string{
 		"flink-app":             "app-name",
 		"flink-app-hash":        hash,
@@ -161,10 +161,10 @@ func TestJobManagerHACreateSuccess(t *testing.T) {
 			assert.Equal(t, "flink.k8s.io/v1beta1", deployment.OwnerReferences[0].APIVersion)
 			assert.Equal(t, "FlinkApplication", deployment.OwnerReferences[0].Kind)
 
-			assert.Equal(t, "blob.server.port: 6125\nhigh-availability: zookeeper\njobmanager.heap.size: 1536\n"+
+			assert.Equal(t, "blob.server.port: 6125\nhigh-availability: zookeeper\njobmanager.heap.size: 1572864k\n"+
 				"jobmanager.rpc.port: 6123\n"+
 				"jobmanager.web.port: 8081\nmetrics.internal.query-service.port: 50101\n"+
-				"query.server.port: 6124\ntaskmanager.heap.size: 512\n"+
+				"query.server.port: 6124\ntaskmanager.heap.size: 524288k\n"+
 				"taskmanager.numberOfTaskSlots: 16\n\n"+
 				"high-availability.cluster-id: app-name-"+hash+"\n"+
 				"jobmanager.rpc.address: $HOST_IP\n",

--- a/pkg/controller/flink/task_manager_controller_test.go
+++ b/pkg/controller/flink/task_manager_controller_test.go
@@ -60,7 +60,7 @@ func TestTaskManagerCreateSuccess(t *testing.T) {
 		"flink-job-properties": "jarName: test.jar\nparallelism: 8\nentryClass:com.test.MainClass\nprogramArgs:\"--test\"",
 	}
 
-	hash := "d62c9c38"
+	hash := "3b2fc68e"
 
 	app.Annotations = annotations
 	expectedLabels := map[string]string{
@@ -79,10 +79,10 @@ func TestTaskManagerCreateSuccess(t *testing.T) {
 		assert.Equal(t, app.Namespace, deployment.Spec.Template.Namespace)
 		assert.Equal(t, expectedLabels, deployment.Labels)
 
-		assert.Equal(t, "blob.server.port: 6125\njobmanager.heap.size: 1536\n"+
+		assert.Equal(t, "blob.server.port: 6125\njobmanager.heap.size: 1572864k\n"+
 			"jobmanager.rpc.port: 6123\n"+
 			"jobmanager.web.port: 8081\nmetrics.internal.query-service.port: 50101\n"+
-			"query.server.port: 6124\ntaskmanager.heap.size: 512\n"+
+			"query.server.port: 6124\ntaskmanager.heap.size: 524288k\n"+
 			"taskmanager.numberOfTaskSlots: 16\n\n"+
 			"jobmanager.rpc.address: app-name-"+hash+"\n"+
 			"taskmanager.host: $HOST_IP\n",
@@ -107,7 +107,7 @@ func TestTaskManagerHACreateSuccess(t *testing.T) {
 		"flink-job-properties": "jarName: test.jar\nparallelism: 8\nentryClass:com.test.MainClass\nprogramArgs:\"--test\"",
 	}
 
-	hash := "063e33b7"
+	hash := "4a2f1a08"
 	app.Spec.FlinkConfig = map[string]interface{}{
 		"high-availability": "zookeeper",
 	}
@@ -128,10 +128,10 @@ func TestTaskManagerHACreateSuccess(t *testing.T) {
 		assert.Equal(t, app.Namespace, deployment.Spec.Template.Namespace)
 		assert.Equal(t, expectedLabels, deployment.Labels)
 
-		assert.Equal(t, "blob.server.port: 6125\nhigh-availability: zookeeper\njobmanager.heap.size: 1536\n"+
+		assert.Equal(t, "blob.server.port: 6125\nhigh-availability: zookeeper\njobmanager.heap.size: 1572864k\n"+
 			"jobmanager.rpc.port: 6123\n"+
 			"jobmanager.web.port: 8081\nmetrics.internal.query-service.port: 50101\n"+
-			"query.server.port: 6124\ntaskmanager.heap.size: 512\n"+
+			"query.server.port: 6124\ntaskmanager.heap.size: 524288k\n"+
 			"taskmanager.numberOfTaskSlots: 16\n\n"+
 			"high-availability.cluster-id: app-name-"+hash+"\n"+
 			"taskmanager.host: $HOST_IP\n",


### PR DESCRIPTION
**Note that this is a breaking change, and will cause redeploy of all flink applications**

This PR fixes how we render Flink heap settings in the config based on the container memory requests and the configured `offHeapMemoryFraction`. This addresses #97, but also fixes a deeper issue where our memory settings were just being ignored.

This is a breaking change which is unfortunate, but also unavoidable in this case, as the current configuration is broken.

Currently we compute the Flink heap settings as `(1 - offHeapMemoryFraction) * requestedMemory`, convert it as a float to MB, then render it in the config like

```
jobmanager.heap.size: 1024
```

However this the wrong format and is ignored, at least by Flink 1.8; it should actually be 

```
jobmanager.heap.size: 1024m
````

In the case of fractional MBs, we print it as, say

```
jobmanager.heap.size: 1024.4
```

which causes startup to crash, as reported in #97. 

This PR fixes both issues by using KBs instead of MBs to give more granularity, rounding to the nearest KB, and including the unit:

```
jobmanager.heap.size: 102440k
```