### PR TITLE
[STRMCMP-616] Improvements to integration test stability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: required
 language: go
-dist: xenial
+dist: bionic
 cache:
   directories:
     - $GOPATH/pkg/dep

--- a/integ/test_app.yaml
+++ b/integ/test_app.yaml
@@ -10,7 +10,6 @@ spec:
   imagePullSecrets:
     - name: dockerhub
   flinkConfig:
-    taskmanager.heap.size: 200
     state.backend.fs.checkpointdir: file:///checkpoints/flink/checkpoints
     state.checkpoints.dir: file:///checkpoints/flink/externalized-checkpoints
     state.savepoints.dir: file:///checkpoints/flink/savepoints
@@ -24,8 +23,10 @@ spec:
     taskSlots: 2
     resources:
       requests:
-        memory: "200Mi"
+        memory: "400Mi"
         cpu: "0.2"
+      limits:
+        memory: "400Mi"
   volumeMounts:
     - mountPath: /checkpoints
       name: checkpoints

--- a/pkg/controller/flink/client/error_handler.go
+++ b/pkg/controller/flink/client/error_handler.go
@@ -100,6 +100,9 @@ func (r RetryHandler) WaitOnError(clock clock.Clock, lastUpdatedTime time.Time) 
 }
 func (r RetryHandler) GetRetryDelay(retryCount int32) time.Duration {
 	timeInMillis := int(r.baseBackOffDuration.Nanoseconds() / int64(time.Millisecond))
+	if timeInMillis <= 0 {
+		timeInMillis = 1
+	}
 	maxBackoffMillis := int(r.maxBackOffMillisDuration.Nanoseconds() / int64(time.Millisecond))
 	delay := 1 << uint(retryCount) * (rand.Intn(timeInMillis) + timeInMillis)
 	return time.Duration(min(delay, maxBackoffMillis)) * time.Millisecond

--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -239,7 +239,7 @@ func (s *FlinkStateMachine) handleNewOrUpdating(ctx context.Context, application
 func (s *FlinkStateMachine) deployFailed(ctx context.Context, app *v1beta1.FlinkApplication) (bool, error) {
 	hash := flink.HashForApplication(app)
 	s.flinkController.LogEvent(ctx, app, corev1.EventTypeWarning, "RolledBackDeploy",
-		fmt.Sprintf("Successfull rolled back deploy %s", hash))
+		fmt.Sprintf("Successful rolled back deploy %s", hash))
 	app.Status.FailedDeployHash = hash
 	// set rollbackHash to deployHash
 	app.Status.RollbackHash = app.Status.DeployHash

--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -239,7 +239,7 @@ func (s *FlinkStateMachine) handleNewOrUpdating(ctx context.Context, application
 func (s *FlinkStateMachine) deployFailed(ctx context.Context, app *v1beta1.FlinkApplication) (bool, error) {
 	hash := flink.HashForApplication(app)
 	s.flinkController.LogEvent(ctx, app, corev1.EventTypeWarning, "RolledBackDeploy",
-		fmt.Sprintf("Successful rolled back deploy %s", hash))
+		fmt.Sprintf("Successfully rolled back deploy %s", hash))
 	app.Status.FailedDeployHash = hash
 	// set rollbackHash to deployHash
 	app.Status.RollbackHash = app.Status.DeployHash


### PR DESCRIPTION
This PR includes a bunch of improvements to integration test stability and usability.

* Improves the "are all tasks running" logic
* Retries FlinkApplication updates on conflicts 
* Uses a bad image for the force rollback test instead of too much memory
* Updates test VM to bionic
* Added more log lines to help diagnose where tests get stuck
* Logging is now plaintext instead of json