### PR TITLE
[STRMCMP-661] Fix bug that could lead to multiple job submission

### DIFF
--- a/pkg/controller/flink/flink.go
+++ b/pkg/controller/flink/flink.go
@@ -170,9 +170,8 @@ func GetActiveFlinkJob(jobs []client.FlinkJob) *client.FlinkJob {
 		return nil
 	}
 	for _, job := range jobs {
-		if job.Status == client.Running ||
-			job.Status == client.Created ||
-			job.Status == client.Finished {
+		if job.Status != client.Canceled &&
+			job.Status != client.Failed {
 			return &job
 		}
 	}

--- a/pkg/controller/flink/flink.go
+++ b/pkg/controller/flink/flink.go
@@ -205,7 +205,6 @@ func (f *Controller) GetJobsForApplication(ctx context.Context, application *v1b
 	return jobResponse.Jobs, nil
 }
 
-
 func (f *Controller) GetJobForApplication(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (*client.FlinkJobOverview, error) {
 	if application.Status.JobStatus.JobID == "" {
 		return nil, nil

--- a/pkg/controller/flink/flink.go
+++ b/pkg/controller/flink/flink.go
@@ -71,6 +71,9 @@ type ControllerInterface interface {
 	// Returns the list of Jobs running on the Flink Cluster for the Application
 	GetJobsForApplication(ctx context.Context, application *v1beta1.FlinkApplication, hash string) ([]client.FlinkJob, error)
 
+	// Returns the current job for the application, if one exists in the cluster
+	GetJobForApplication(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (*client.FlinkJobOverview, error)
+
 	// Returns the pair of deployments (tm/jm) for the current version of the application
 	GetCurrentDeploymentsForApp(ctx context.Context, application *v1beta1.FlinkApplication) (*common.FlinkDeployment, error)
 
@@ -165,17 +168,17 @@ func getExternalURLFromApp(application *v1beta1.FlinkApplication) string {
 	return GetFlinkUIIngressURL(application.Name)
 }
 
-func GetActiveFlinkJob(jobs []client.FlinkJob) *client.FlinkJob {
-	if len(jobs) == 0 {
-		return nil
-	}
+func GetActiveFlinkJobs(jobs []client.FlinkJob) []client.FlinkJob {
+	var activeJobs []client.FlinkJob
+
 	for _, job := range jobs {
 		if job.Status != client.Canceled &&
 			job.Status != client.Failed {
-			return &job
+			activeJobs = append(activeJobs, job)
 		}
 	}
-	return nil
+
+	return activeJobs
 }
 
 // Returns true iff the deployment exactly matches the flink application
@@ -200,6 +203,20 @@ func (f *Controller) GetJobsForApplication(ctx context.Context, application *v1b
 	}
 
 	return jobResponse.Jobs, nil
+}
+
+
+func (f *Controller) GetJobForApplication(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (*client.FlinkJobOverview, error) {
+	if application.Status.JobStatus.JobID == "" {
+		return nil, nil
+	}
+
+	jobResponse, err := f.flinkClient.GetJobOverview(ctx, getURLFromApp(application, hash), application.Status.JobStatus.JobID)
+	if err != nil {
+		return nil, err
+	}
+
+	return jobResponse, nil
 }
 
 // The operator for now assumes and is intended to run single application per Flink Cluster.

--- a/pkg/controller/flink/flink_test.go
+++ b/pkg/controller/flink/flink_test.go
@@ -277,9 +277,9 @@ func TestGetActiveJob(t *testing.T) {
 	jobs := []client.FlinkJob{
 		job,
 	}
-	activeJob := GetActiveFlinkJob(jobs)
-	assert.NotNil(t, activeJob)
-	assert.Equal(t, *activeJob, job)
+	activeJob := GetActiveFlinkJobs(jobs)
+	assert.Equal(t, 1, len(activeJob))
+	assert.Equal(t, job, activeJob[0])
 }
 
 func TestGetActiveJobFinished(t *testing.T) {
@@ -290,9 +290,9 @@ func TestGetActiveJobFinished(t *testing.T) {
 	jobs := []client.FlinkJob{
 		job,
 	}
-	activeJob := GetActiveFlinkJob(jobs)
-	assert.NotNil(t, activeJob)
-	assert.Equal(t, *activeJob, job)
+	activeJob := GetActiveFlinkJobs(jobs)
+	assert.Equal(t, 1, len(activeJob))
+	assert.Equal(t, job, activeJob[0])
 }
 
 func TestGetActiveJobNil(t *testing.T) {
@@ -303,14 +303,14 @@ func TestGetActiveJobNil(t *testing.T) {
 	jobs := []client.FlinkJob{
 		job,
 	}
-	activeJob := GetActiveFlinkJob(jobs)
-	assert.Nil(t, activeJob)
+	activeJob := GetActiveFlinkJobs(jobs)
+	assert.Equal(t, 0, len(activeJob))
 }
 
 func TestGetActiveJobEmpty(t *testing.T) {
 	jobs := []client.FlinkJob{}
-	activeJob := GetActiveFlinkJob(jobs)
-	assert.Nil(t, activeJob)
+	activeJob := GetActiveFlinkJobs(jobs)
+	assert.Equal(t, 0, len(activeJob))
 }
 
 func TestDeleteOldResources(t *testing.T) {

--- a/pkg/controller/flink/flink_test.go
+++ b/pkg/controller/flink/flink_test.go
@@ -297,7 +297,7 @@ func TestGetActiveJobFinished(t *testing.T) {
 
 func TestGetActiveJobNil(t *testing.T) {
 	job := client.FlinkJob{
-		Status: client.Cancelling,
+		Status: client.Canceled,
 		JobID:  "j1",
 	}
 	jobs := []client.FlinkJob{

--- a/pkg/controller/flink/mock/mock_error_handler.go
+++ b/pkg/controller/flink/mock/mock_error_handler.go
@@ -51,7 +51,7 @@ func (e RetryHandler) WaitOnError(clock clock.Clock, lastUpdatedTime time.Time) 
 		return e.WaitOnErrorFunc(clock, lastUpdatedTime)
 	}
 
-	return time.Duration(time.Now().UnixNano()), false
+	return time.Duration(time.Now().UnixNano()), true
 }
 
 func (e RetryHandler) GetRetryDelay(retryCount int32) time.Duration {

--- a/pkg/controller/flink/mock/mock_flink.go
+++ b/pkg/controller/flink/mock/mock_flink.go
@@ -19,6 +19,7 @@ type GetSavepointStatusFunc func(ctx context.Context, application *v1beta1.Flink
 type IsClusterReadyFunc func(ctx context.Context, application *v1beta1.FlinkApplication) (bool, error)
 type IsServiceReadyFunc func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (bool, error)
 type GetJobsForApplicationFunc func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) ([]client.FlinkJob, error)
+type GetJobForApplicationFunc func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (*client.FlinkJobOverview, error)
 type GetCurrentDeploymentsForAppFunc func(ctx context.Context, application *v1beta1.FlinkApplication) (*common.FlinkDeployment, error)
 type FindExternalizedCheckpointFunc func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (string, error)
 type CompareAndUpdateClusterStatusFunc func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (bool, error)
@@ -34,6 +35,7 @@ type FlinkController struct {
 	IsClusterReadyFunc                IsClusterReadyFunc
 	IsServiceReadyFunc                IsServiceReadyFunc
 	GetJobsForApplicationFunc         GetJobsForApplicationFunc
+	GetJobForApplicationFunc          GetJobForApplicationFunc
 	GetCurrentDeploymentsForAppFunc   GetCurrentDeploymentsForAppFunc
 	FindExternalizedCheckpointFunc    FindExternalizedCheckpointFunc
 	Events                            []corev1.Event
@@ -111,6 +113,14 @@ func (m *FlinkController) GetJobsForApplication(ctx context.Context, application
 	}
 	return nil, nil
 }
+
+func (m *FlinkController) GetJobForApplication(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (*client.FlinkJobOverview, error) {
+	if m.GetJobForApplicationFunc != nil {
+		return m.GetJobForApplicationFunc(ctx, application, hash)
+	}
+	return nil, nil
+}
+
 
 func (m *FlinkController) FindExternalizedCheckpoint(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (string, error) {
 	if m.FindExternalizedCheckpointFunc != nil {

--- a/pkg/controller/flink/mock/mock_flink.go
+++ b/pkg/controller/flink/mock/mock_flink.go
@@ -121,7 +121,6 @@ func (m *FlinkController) GetJobForApplication(ctx context.Context, application 
 	return nil, nil
 }
 
-
 func (m *FlinkController) FindExternalizedCheckpoint(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (string, error) {
 	if m.FindExternalizedCheckpointFunc != nil {
 		return m.FindExternalizedCheckpointFunc(ctx, application, hash)

--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -280,6 +280,7 @@ func (s *FlinkStateMachine) handleClusterStarting(ctx context.Context, applicati
 func (s *FlinkStateMachine) handleApplicationSavepointing(ctx context.Context, application *v1beta1.FlinkApplication) (bool, error) {
 	// we've already savepointed (or this is our first deploy), continue on
 	if application.Spec.SavepointInfo.SavepointLocation != "" || application.Status.DeployHash == "" {
+		application.Status.JobStatus.JobID = ""
 		s.updateApplicationPhase(application, v1beta1.FlinkApplicationSubmittingJob)
 		return applicationChanged, nil
 	}
@@ -348,6 +349,7 @@ func (s *FlinkStateMachine) handleApplicationSavepointing(ctx context.Context, a
 
 	if restorePath != "" {
 		application.Spec.SavepointInfo.SavepointLocation = restorePath
+		application.Status.JobStatus.JobID = ""
 		s.updateApplicationPhase(application, v1beta1.FlinkApplicationSubmittingJob)
 		return applicationChanged, nil
 	}
@@ -356,47 +358,53 @@ func (s *FlinkStateMachine) handleApplicationSavepointing(ctx context.Context, a
 }
 
 func (s *FlinkStateMachine) submitJobIfNeeded(ctx context.Context, app *v1beta1.FlinkApplication, hash string,
-	jarName string, parallelism int32, entryClass string, programArgs string, allowNonRestoredState bool) (*client.FlinkJob, error) {
+	jarName string, parallelism int32, entryClass string, programArgs string, allowNonRestoredState bool) (string, error) {
 	isReady, _ := s.flinkController.IsServiceReady(ctx, app, hash)
 	// Ignore errors
 	if !isReady {
-		return nil, nil
+		return "", nil
 	}
 
 	// add the job running finalizer if necessary
 	if err := s.addFinalizerIfMissing(ctx, app, jobFinalizer); err != nil {
-		return nil, err
+		return "", err
+	}
+
+	// Check if the job id has already been set on our application
+	if app.Status.JobStatus.JobID != "" {
+		return app.Status.JobStatus.JobID, nil
 	}
 
 	// Check that there are no jobs running before starting the job
 	jobs, err := s.flinkController.GetJobsForApplication(ctx, app, hash)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
-	if len(jobs) == 0 {
-		logger.Infof(ctx, "No active job found for the application %v", jobs)
+	activeJobs := flink.GetActiveFlinkJobs(jobs)
+
+	switch n := len(activeJobs); n {
+	case 0:
+		// no active jobs, we need to submit a new one
+		logger.Infof(ctx, "No job found for the application")
 		jobID, err := s.flinkController.StartFlinkJob(ctx, app, hash,
 			jarName, parallelism, entryClass, programArgs, allowNonRestoredState)
 		if err != nil {
 			s.flinkController.LogEvent(ctx, app, corev1.EventTypeWarning, "JobSubmissionFailed",
 				fmt.Sprintf("Failed to submit job to cluster for deploy %s: %v", hash, err))
-
-			// TODO: we probably want some kind of back-off here
-			return nil, err
+			return "", err
 		}
 
 		s.flinkController.LogEvent(ctx, app, corev1.EventTypeNormal, "JobSubmitted",
 			fmt.Sprintf("Flink job submitted to cluster with id %s", jobID))
-		app.Status.JobStatus.JobID = jobID
-		return nil, nil
-	} else {
-		if len(jobs) > 1 {
-			logger.Warn(ctx, "Found multiple jobs in cluster")
-		}
-
-		app.Status.JobStatus.JobID = jobs[0].JobID
-		return &jobs[0], nil
+		return jobID, nil
+	case 1:
+		// there's one active job, we must have failed to save the update after job submission in a previous cycle
+		logger.Warnf(ctx, "Found already-submitted job for application with id %s", activeJobs[0].JobID)
+		return activeJobs[0].JobID, nil
+	default:
+		// there's more than one active jobs, something has gone terribly wrong
+		return "", errors.New("found multiple active jobs for application")
 	}
 }
 
@@ -446,13 +454,29 @@ func (s *FlinkStateMachine) handleSubmittingJob(ctx context.Context, app *v1beta
 		logger.Errorf(ctx, "Updating cluster status failed with error: %v", clusterErr)
 	}
 
-	activeJob, err := s.submitJobIfNeeded(ctx, app, hash,
-		app.Spec.JarName, app.Spec.Parallelism, app.Spec.EntryClass, app.Spec.ProgramArgs, app.Spec.AllowNonRestoredState)
+	if app.Status.JobStatus.JobID == "" {
+		appJobId, err := s.submitJobIfNeeded(ctx, app, hash,
+			app.Spec.JarName, app.Spec.Parallelism, app.Spec.EntryClass, app.Spec.ProgramArgs, app.Spec.AllowNonRestoredState)
+		if err != nil {
+			return applicationUnchanged, err
+		}
+
+		if appJobId != "" {
+			app.Status.JobStatus.JobID = appJobId
+			return applicationChanged, nil
+		}
+
+		// we weren't ready to submit yet
+		return applicationUnchanged, nil
+	}
+
+	// get the state of the current application
+	job, err := s.flinkController.GetJobForApplication(ctx, app, hash)
 	if err != nil {
 		return applicationUnchanged, err
 	}
 
-	if activeJob != nil && activeJob.Status == client.Running {
+	if job.State == client.Running {
 		// Clear the savepoint info
 		app.Spec.SavepointInfo = v1beta1.SavepointInfo{}
 		// Update the application status with the running job info
@@ -503,7 +527,7 @@ func (s *FlinkStateMachine) handleRollingBack(ctx context.Context, app *v1beta1.
 	}
 
 	// submit the old job
-	activeJob, err := s.submitJobIfNeeded(ctx, app, app.Status.DeployHash,
+	jobId, err := s.submitJobIfNeeded(ctx, app, app.Status.DeployHash,
 		app.Status.JobStatus.JarName, app.Status.JobStatus.Parallelism,
 		app.Status.JobStatus.EntryClass, app.Status.JobStatus.ProgramArgs,
 		app.Status.JobStatus.AllowNonRestoredState)
@@ -514,7 +538,8 @@ func (s *FlinkStateMachine) handleRollingBack(ctx context.Context, app *v1beta1.
 		return applicationUnchanged, err
 	}
 
-	if activeJob != nil {
+	if jobId != "" {
+		app.Status.JobStatus.JobID = jobId
 		app.Spec.SavepointInfo = v1beta1.SavepointInfo{}
 		// move to the deploy failed state
 		return s.deployFailed(ctx, app)
@@ -526,21 +551,17 @@ func (s *FlinkStateMachine) handleRollingBack(ctx context.Context, app *v1beta1.
 // Check if the application is Running.
 // This is a stable state. Keep monitoring if the underlying CRD reflects the Flink cluster
 func (s *FlinkStateMachine) handleApplicationRunning(ctx context.Context, application *v1beta1.FlinkApplication) (bool, error) {
-	jobs, err := s.flinkController.GetJobsForApplication(ctx, application, application.Status.DeployHash)
+	job, err := s.flinkController.GetJobForApplication(ctx, application, application.Status.DeployHash)
 	if err != nil {
 		// TODO: think more about this case
 		return applicationUnchanged, err
 	}
 
-	// The jobid in Flink can change if there is a Job manager failover.
-	// The Operator needs to update its state with the right value.
-	// In the Running state, there must be a job already started in the cluster.
-	activeJob := flink.GetActiveFlinkJob(jobs)
-	if activeJob != nil {
-		application.Status.JobStatus.JobID = activeJob.JobID
+	if job == nil {
+		logger.Warnf(ctx, "Could not find active job {}", application.Status.JobStatus.JobID)
+	} else {
+		logger.Debugf(ctx, "Application running with job %v", job.JobID)
 	}
-
-	logger.Debugf(ctx, "Application running with job %v", activeJob)
 
 	cur, err := s.flinkController.GetCurrentDeploymentsForApp(ctx, application)
 	if err != nil {
@@ -610,16 +631,11 @@ func (s *FlinkStateMachine) clearFinalizers(app *v1beta1.FlinkApplication) (bool
 	return applicationChanged, nil
 }
 
-func jobFinished(jobs []client.FlinkJob, id string) bool {
-	for _, job := range jobs {
-		if job.JobID == id {
-			return job.Status == client.Canceled ||
-				job.Status == client.Failed ||
-				job.Status == client.Finished
-		}
-	}
-
-	return true
+func jobFinished(job *client.FlinkJobOverview) bool {
+	return job == nil ||
+		job.State== client.Canceled ||
+		job.State == client.Failed ||
+		job.State == client.Finished
 }
 
 func (s *FlinkStateMachine) handleApplicationDeleting(ctx context.Context, app *v1beta1.FlinkApplication) (bool, error) {
@@ -634,14 +650,12 @@ func (s *FlinkStateMachine) handleApplicationDeleting(ctx context.Context, app *
 		return s.clearFinalizers(app)
 	}
 
-	jobs, err := s.flinkController.GetJobsForApplication(ctx, app, app.Status.DeployHash)
+	job, err := s.flinkController.GetJobForApplication(ctx, app, app.Status.DeployHash)
 	if err != nil {
 		return applicationUnchanged, err
 	}
 
-	finished := jobFinished(jobs, app.Status.JobStatus.JobID)
-
-	if len(jobs) == 0 || finished {
+	if jobFinished(job) {
 		// there are no running jobs for this application, we can just tear down
 		return s.clearFinalizers(app)
 	}

--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -455,14 +455,14 @@ func (s *FlinkStateMachine) handleSubmittingJob(ctx context.Context, app *v1beta
 	}
 
 	if app.Status.JobStatus.JobID == "" {
-		appJobId, err := s.submitJobIfNeeded(ctx, app, hash,
+		appJobID, err := s.submitJobIfNeeded(ctx, app, hash,
 			app.Spec.JarName, app.Spec.Parallelism, app.Spec.EntryClass, app.Spec.ProgramArgs, app.Spec.AllowNonRestoredState)
 		if err != nil {
 			return applicationUnchanged, err
 		}
 
-		if appJobId != "" {
-			app.Status.JobStatus.JobID = appJobId
+		if appJobID != "" {
+			app.Status.JobStatus.JobID = appJobID
 			return applicationChanged, nil
 		}
 
@@ -527,7 +527,7 @@ func (s *FlinkStateMachine) handleRollingBack(ctx context.Context, app *v1beta1.
 	}
 
 	// submit the old job
-	jobId, err := s.submitJobIfNeeded(ctx, app, app.Status.DeployHash,
+	jobID, err := s.submitJobIfNeeded(ctx, app, app.Status.DeployHash,
 		app.Status.JobStatus.JarName, app.Status.JobStatus.Parallelism,
 		app.Status.JobStatus.EntryClass, app.Status.JobStatus.ProgramArgs,
 		app.Status.JobStatus.AllowNonRestoredState)
@@ -538,8 +538,8 @@ func (s *FlinkStateMachine) handleRollingBack(ctx context.Context, app *v1beta1.
 		return applicationUnchanged, err
 	}
 
-	if jobId != "" {
-		app.Status.JobStatus.JobID = jobId
+	if jobID != "" {
+		app.Status.JobStatus.JobID = jobID
 		app.Spec.SavepointInfo = v1beta1.SavepointInfo{}
 		// move to the deploy failed state
 		return s.deployFailed(ctx, app)
@@ -633,7 +633,7 @@ func (s *FlinkStateMachine) clearFinalizers(app *v1beta1.FlinkApplication) (bool
 
 func jobFinished(job *client.FlinkJobOverview) bool {
 	return job == nil ||
-		job.State== client.Canceled ||
+		job.State == client.Canceled ||
 		job.State == client.Failed ||
 		job.State == client.Finished
 }

--- a/pkg/controller/flinkapplication/flink_state_machine_test.go
+++ b/pkg/controller/flinkapplication/flink_state_machine_test.go
@@ -309,7 +309,7 @@ func TestSubmittingToRunning(t *testing.T) {
 	mockFlinkController.GetJobForApplicationFunc = func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (*client.FlinkJobOverview, error) {
 		assert.Equal(t, appHash, hash)
 		return &client.FlinkJobOverview{
-			JobID:  jobID,
+			JobID: jobID,
 			State: client.Running,
 		}, nil
 	}
@@ -682,7 +682,7 @@ func TestDeleteWithSavepoint(t *testing.T) {
 
 	mockFlinkController.GetJobForApplicationFunc = func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (jobs *client.FlinkJobOverview, err error) {
 		return &client.FlinkJobOverview{
-			JobID:  jobID,
+			JobID: jobID,
 			State: "RUNNING",
 		}, nil
 	}
@@ -749,14 +749,13 @@ func TestDeleteWithSavepoint(t *testing.T) {
 
 	mockFlinkController.GetJobForApplicationFunc = func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (jobs *client.FlinkJobOverview, err error) {
 		return &client.FlinkJobOverview{
-			JobID:  jobID,
+			JobID: jobID,
 			State: "CANCELED",
 		}, nil
 	}
 
 	err = stateMachineForTest.Handle(context.Background(), &app)
 	assert.NoError(t, err)
-
 
 	assert.Equal(t, 5, updateCount)
 
@@ -832,7 +831,7 @@ func TestDeleteWithForceCancel(t *testing.T) {
 
 	mockFlinkController.GetJobForApplicationFunc = func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (*client.FlinkJobOverview, error) {
 		return &client.FlinkJobOverview{
-			JobID:  jobID,
+			JobID: jobID,
 			State: "RUNNING",
 		}, nil
 	}
@@ -864,7 +863,7 @@ func TestDeleteWithForceCancel(t *testing.T) {
 
 	mockFlinkController.GetJobForApplicationFunc = func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (*client.FlinkJobOverview, error) {
 		return &client.FlinkJobOverview{
-			JobID:  jobID,
+			JobID: jobID,
 			State: "CANCELED",
 		}, nil
 	}

--- a/pkg/controller/flinkapplication/flink_state_machine_test.go
+++ b/pkg/controller/flinkapplication/flink_state_machine_test.go
@@ -307,15 +307,14 @@ func TestSubmittingToRunning(t *testing.T) {
 	}
 
 	getCount := 0
-	mockFlinkController.GetJobsForApplicationFunc = func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) ([]client.FlinkJob, error) {
+	mockFlinkController.GetJobForApplicationFunc = func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (*client.FlinkJobOverview, error) {
 		assert.Equal(t, appHash, hash)
-		var res []client.FlinkJob
+		var res *client.FlinkJobOverview
 		if getCount == 1 {
-			res = []client.FlinkJob{
-				{
-					JobID:  jobID,
-					Status: client.Running,
-				}}
+			res = &client.FlinkJobOverview{
+				JobID:  jobID,
+				State: client.Running,
+			}
 		}
 		getCount++
 		return res, nil

--- a/pkg/controller/flinkapplication/flink_state_machine_test.go
+++ b/pkg/controller/flinkapplication/flink_state_machine_test.go
@@ -306,18 +306,12 @@ func TestSubmittingToRunning(t *testing.T) {
 		return true, nil
 	}
 
-	getCount := 0
 	mockFlinkController.GetJobForApplicationFunc = func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (*client.FlinkJobOverview, error) {
 		assert.Equal(t, appHash, hash)
-		var res *client.FlinkJobOverview
-		if getCount == 1 {
-			res = &client.FlinkJobOverview{
-				JobID:  jobID,
-				State: client.Running,
-			}
-		}
-		getCount++
-		return res, nil
+		return &client.FlinkJobOverview{
+			JobID:  jobID,
+			State: client.Running,
+		}, nil
 	}
 
 	startCount := 0
@@ -373,6 +367,8 @@ func TestSubmittingToRunning(t *testing.T) {
 		} else if updateCount == 2 {
 			application := object.(*v1beta1.FlinkApplication)
 			assert.Equal(t, jobID, application.Status.JobStatus.JobID)
+		} else if updateCount == 3 {
+			application := object.(*v1beta1.FlinkApplication)
 			assert.Equal(t, appHash, application.Status.DeployHash)
 			assert.Equal(t, app.Spec.JarName, app.Status.JobStatus.JarName)
 			assert.Equal(t, app.Spec.Parallelism, app.Status.JobStatus.Parallelism)
@@ -390,9 +386,8 @@ func TestSubmittingToRunning(t *testing.T) {
 	err = stateMachineForTest.Handle(context.Background(), &app)
 	assert.Nil(t, err)
 
-	assert.Equal(t, 2, getCount)
 	assert.Equal(t, 1, startCount)
-	assert.Equal(t, 3, updateCount)
+	assert.Equal(t, 4, updateCount)
 }
 
 func TestHandleApplicationNotReady(t *testing.T) {
@@ -599,7 +594,7 @@ func TestRollingBack(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.True(t, startCalled)
-	assert.Equal(t, 3, updateCount)
+	assert.Equal(t, 4, updateCount)
 }
 
 func TestIsApplicationStuck(t *testing.T) {
@@ -685,12 +680,10 @@ func TestDeleteWithSavepoint(t *testing.T) {
 		return triggerID, nil
 	}
 
-	mockFlinkController.GetJobsForApplicationFunc = func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (jobs []client.FlinkJob, err error) {
-		return []client.FlinkJob{
-			{
-				JobID:  jobID,
-				Status: "RUNNING",
-			},
+	mockFlinkController.GetJobForApplicationFunc = func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (jobs *client.FlinkJobOverview, err error) {
+		return &client.FlinkJobOverview{
+			JobID:  jobID,
+			State: "RUNNING",
 		}, nil
 	}
 
@@ -754,17 +747,16 @@ func TestDeleteWithSavepoint(t *testing.T) {
 
 	assert.Equal(t, 4, updateCount)
 
-	mockFlinkController.GetJobsForApplicationFunc = func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (jobs []client.FlinkJob, err error) {
-		return []client.FlinkJob{
-			{
-				JobID:  jobID,
-				Status: "CANCELED",
-			},
+	mockFlinkController.GetJobForApplicationFunc = func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (jobs *client.FlinkJobOverview, err error) {
+		return &client.FlinkJobOverview{
+			JobID:  jobID,
+			State: "CANCELED",
 		}, nil
 	}
 
 	err = stateMachineForTest.Handle(context.Background(), &app)
 	assert.NoError(t, err)
+
 
 	assert.Equal(t, 5, updateCount)
 
@@ -838,12 +830,10 @@ func TestDeleteWithForceCancel(t *testing.T) {
 
 	mockFlinkController := stateMachineForTest.flinkController.(*mock.FlinkController)
 
-	mockFlinkController.GetJobsForApplicationFunc = func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (jobs []client.FlinkJob, err error) {
-		return []client.FlinkJob{
-			{
-				JobID:  jobID,
-				Status: "RUNNING",
-			},
+	mockFlinkController.GetJobForApplicationFunc = func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (*client.FlinkJobOverview, error) {
+		return &client.FlinkJobOverview{
+			JobID:  jobID,
+			State: "RUNNING",
 		}, nil
 	}
 
@@ -872,12 +862,10 @@ func TestDeleteWithForceCancel(t *testing.T) {
 	assert.Equal(t, 1, updateCount)
 	assert.True(t, cancelled)
 
-	mockFlinkController.GetJobsForApplicationFunc = func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (jobs []client.FlinkJob, err error) {
-		return []client.FlinkJob{
-			{
-				JobID:  jobID,
-				Status: "CANCELED",
-			},
+	mockFlinkController.GetJobForApplicationFunc = func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (*client.FlinkJobOverview, error) {
+		return &client.FlinkJobOverview{
+			JobID:  jobID,
+			State: "CANCELED",
 		}, nil
 	}
 
@@ -1141,7 +1129,7 @@ func TestErrorHandlingInRunningPhase(t *testing.T) {
 	stateMachineForTest := getTestStateMachine()
 	mockFlinkController := stateMachineForTest.flinkController.(*mock.FlinkController)
 
-	mockFlinkController.GetJobsForApplicationFunc = func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) ([]client.FlinkJob, error) {
+	mockFlinkController.GetJobForApplicationFunc = func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (*client.FlinkJobOverview, error) {
 		return nil, client.GetNonRetryableError(errors.New("running phase error"), "TestError", "400")
 	}
 


### PR DESCRIPTION
This PR fixes a bug that could lead to multiple jobs being submitted during the SubmittingJob phase. This would happen if a job was failing during the deploy process; because the activeJobs filter was excluding failing jobs, the operator would think that there was no job running and would resubmit another.

I've also taken this opportunity to make the operator more opinionated about _which_ job it's managing in the cluster. Whereas previously we would query for all jobs in the cluster and take the first "active" one, we now rely on the jobId we've stored in our state to determine which is our job. 

If this changes somehow from underneath us (like if the user cancels the job through the API and submits a new job) we should not continue on as if everything is well, as future operations are likely to fail or lead to unexpected outcomes anyways.