### PR TITLE
Use a separate error metric for update conflicts

### DIFF
--- a/pkg/controller/k8/cluster.go
+++ b/pkg/controller/k8/cluster.go
@@ -2,6 +2,7 @@ package k8
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/lyft/flinkk8soperator/pkg/controller/config"


### PR DESCRIPTION
Currently we have a single error metric for update failures. This PR adds a separate metric for conflicts, which are a client error and do not indicate anything is wrong with the api server.