### PR TITLE
[STRMCMP-639] Trigger immediate rollback when job submission fails

### DIFF
--- a/pkg/controller/flink/client/api.go
+++ b/pkg/controller/flink/client/api.go
@@ -38,6 +38,13 @@ const retryCount = 3
 const httpGetTimeOut = 5 * time.Second
 const defaultTimeOut = 1 * time.Minute
 
+// ProgramInvocationException is thrown when the entry class doesn't exist or throws an exception
+const programInvocationException = "org.apache.flink.client.program.ProgramInvocationException"
+
+// JobSubmissionException is thrown when there is an error submitting the job (e.g., the savepoint is
+// incompatible, classes for parts of the jobgraph cannot be found, jobgraph is invalid, etc.)
+const jobSubmissionException = "org.apache.flink.runtime.client.JobSubmissionException"
+
 type FlinkAPIInterface interface {
 	CancelJobWithSavepoint(ctx context.Context, url string, jobID string) (string, error)
 	ForceCancelJob(ctx context.Context, url string, jobID string) error
@@ -231,11 +238,7 @@ func (c *FlinkJobManagerClient) SubmitJob(ctx context.Context, url string, jarID
 			// Flink returns a 500 when the entry class doesn't exist or crashes on start, but we want to fail fast
 			// in those cases
 			body := response.String()
-			// ProgramInvocationException is thrown when the entry class doesn't exist or throws an exception
-			if strings.Contains(body, "org.apache.flink.client.program.ProgramInvocationException") ||
-				// JobSubmissionException is thrown when there is an error submitting the job (e.g., the savepoint is
-				// incompatible, classes for parts of the jobgraph cannot be found, jobgraph is invalid, etc.)
-				strings.Contains(body, "org.apache.flink.runtime.client.JobSubmissionException") {
+			if strings.Contains(body, programInvocationException) || strings.Contains(body, jobSubmissionException) {
 				return nil, GetNonRetryableErrorWithMessage(err, v1beta1.SubmitJob, response.Status(), body)
 			}
 			return nil, GetRetryableErrorWithMessage(err, v1beta1.SubmitJob, response.Status(), DefaultRetries, string(response.Body()))


### PR DESCRIPTION
This PR adds another case to our immediate rollback (i.e., unretryable error) logic, that catches the case where the job submission fails. This typically happens due to an incompatible savepoint or an invalid jobgraph.