### PR TITLE
[STRMCMP-675] Enable status subresource in CRD

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The operator is in use for some less-critical jobs at Lyft. At this point the fo
 Beta, we will attempt to limit the number of backwards-incompatible changes, but they may still occur as necessary. 
 
 ## Prerequisites
-* Version >= 1.9 of Kubernetes.
+* Version >= 1.10 of Kubernetes (versions < 1.13 require `--feature-gates=CustomResourceSubresources=true`)
 * Version >= 1.7 of Apache Flink.
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ FlinkK8sOperator is a [Kubernetes operator](https://coreos.com/operators/) that 
 
 *Beta*
 
-The operator is in use for some less-crtical jobs at Lyft. At this point the focus is on testing and stability While in 
+The operator is in use for some less-critical jobs at Lyft. At this point the focus is on testing and stability While in 
 Beta, we will attempt to limit the number of backwards-incompatible changes, but they may still occur as necessary. 
 
 ## Prerequisites

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -89,6 +89,8 @@ spec:
               properties:
                 savepointLocation:
                   type: string
+            savepointPath:
+              type: string
             jobManagerConfig:
               type: object
               properties:
@@ -377,7 +379,8 @@ spec:
             - jarName
             - parallelism
             - entryClass
-
+  subresources:
+    status: {}
   additionalPrinterColumns:
     - name: Phase
       type: string

--- a/docs/crd.md
+++ b/docs/crd.md
@@ -74,12 +74,12 @@ Below is the list of fields in the custom resource and their description
 
   * **programArgs** `type:string`
     External configuration parameters to be passed as arguments to the job like input and output sources, etc
-    
+
+  * **savepointPath** `type:string`
+    If specified, the application state will be restored from this savepoint    
+
   * **allowNonRestoredState** `type:boolean`
     Skips savepoint operator state that cannot be mapped to the new program version  
-
-  * **savepointInfo** `type:SavepointInfo`
-    Optional Savepoint info that can be passed in to indicate that the Flink job must resume from the corresponding savepoint.
 
   * **flinkVersion** `type:string required=true`
     The version of Flink to be managed. This version must match the version in the image.

--- a/integ/simple_test.go
+++ b/integ/simple_test.go
@@ -218,7 +218,7 @@ func (s *IntegSuite) TestSimple(c *C) {
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	c.Assert(app.Spec.SavepointInfo.SavepointLocation, NotNil)
+	c.Assert(app.Status.SavepointPath, NotNil)
 	job := func() map[string]interface{} {
 		jobs, _ := s.Util.FlinkAPIGet(app, "/jobs")
 		jobMap := jobs.(map[string]interface{})

--- a/pkg/apis/app/v1beta1/types.go
+++ b/pkg/apis/app/v1beta1/types.go
@@ -40,7 +40,7 @@ type FlinkApplicationSpec struct {
 	Parallelism        int32                        `json:"parallelism"`
 	EntryClass         string                       `json:"entryClass,omitempty"`
 	ProgramArgs        string                       `json:"programArgs,omitempty"`
-	// Deprecated
+	// Deprecated: use SavepointPath instead
 	SavepointInfo         SavepointInfo       `json:"savepointInfo,omitempty"`
 	SavepointPath         string              `json:"savepointPath,omitempty"`
 	DeploymentMode        DeploymentMode      `json:"deploymentMode,omitempty"`

--- a/pkg/apis/app/v1beta1/types.go
+++ b/pkg/apis/app/v1beta1/types.go
@@ -28,33 +28,33 @@ type FlinkApplication struct {
 }
 
 type FlinkApplicationSpec struct {
-	Image                 string                       `json:"image,omitempty" protobuf:"bytes,2,opt,name=image"`
-	ImagePullPolicy       apiv1.PullPolicy             `json:"imagePullPolicy,omitempty" protobuf:"bytes,14,opt,name=imagePullPolicy,casttype=PullPolicy"`
-	ImagePullSecrets      []apiv1.LocalObjectReference `json:"imagePullSecrets,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,15,rep,name=imagePullSecrets"`
-	ServiceAccountName    string                       `json:"serviceAccountName,omitempty"`
-	FlinkConfig           FlinkConfig                  `json:"flinkConfig"`
-	FlinkVersion          string                       `json:"flinkVersion"`
-	TaskManagerConfig     TaskManagerConfig            `json:"taskManagerConfig,omitempty"`
-	JobManagerConfig      JobManagerConfig             `json:"jobManagerConfig,omitempty"`
-	JarName               string                       `json:"jarName"`
-	Parallelism           int32                        `json:"parallelism"`
-	EntryClass            string                       `json:"entryClass,omitempty"`
-	ProgramArgs           string                       `json:"programArgs,omitempty"`
+	Image              string                       `json:"image,omitempty" protobuf:"bytes,2,opt,name=image"`
+	ImagePullPolicy    apiv1.PullPolicy             `json:"imagePullPolicy,omitempty" protobuf:"bytes,14,opt,name=imagePullPolicy,casttype=PullPolicy"`
+	ImagePullSecrets   []apiv1.LocalObjectReference `json:"imagePullSecrets,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,15,rep,name=imagePullSecrets"`
+	ServiceAccountName string                       `json:"serviceAccountName,omitempty"`
+	FlinkConfig        FlinkConfig                  `json:"flinkConfig"`
+	FlinkVersion       string                       `json:"flinkVersion"`
+	TaskManagerConfig  TaskManagerConfig            `json:"taskManagerConfig,omitempty"`
+	JobManagerConfig   JobManagerConfig             `json:"jobManagerConfig,omitempty"`
+	JarName            string                       `json:"jarName"`
+	Parallelism        int32                        `json:"parallelism"`
+	EntryClass         string                       `json:"entryClass,omitempty"`
+	ProgramArgs        string                       `json:"programArgs,omitempty"`
 	// Deprecated
-	SavepointInfo         SavepointInfo                `json:"savepointInfo,omitempty"`
-	SavepointPath         string                       `json:"savepointPath,omitempty"`
-	DeploymentMode        DeploymentMode               `json:"deploymentMode,omitempty"`
-	RPCPort               *int32                       `json:"rpcPort,omitempty"`
-	BlobPort              *int32                       `json:"blobPort,omitempty"`
-	QueryPort             *int32                       `json:"queryPort,omitempty"`
-	UIPort                *int32                       `json:"uiPort,omitempty"`
-	MetricsQueryPort      *int32                       `json:"metricsQueryPort,omitempty"`
-	Volumes               []apiv1.Volume               `json:"volumes,omitempty"`
-	VolumeMounts          []apiv1.VolumeMount          `json:"volumeMounts,omitempty"`
-	RestartNonce          string                       `json:"restartNonce"`
-	DeleteMode            DeleteMode                   `json:"deleteMode,omitempty"`
-	AllowNonRestoredState bool                         `json:"allowNonRestoredState,omitempty"`
-	ForceRollback         bool                         `json:"forceRollback"`
+	SavepointInfo         SavepointInfo       `json:"savepointInfo,omitempty"`
+	SavepointPath         string              `json:"savepointPath,omitempty"`
+	DeploymentMode        DeploymentMode      `json:"deploymentMode,omitempty"`
+	RPCPort               *int32              `json:"rpcPort,omitempty"`
+	BlobPort              *int32              `json:"blobPort,omitempty"`
+	QueryPort             *int32              `json:"queryPort,omitempty"`
+	UIPort                *int32              `json:"uiPort,omitempty"`
+	MetricsQueryPort      *int32              `json:"metricsQueryPort,omitempty"`
+	Volumes               []apiv1.Volume      `json:"volumes,omitempty"`
+	VolumeMounts          []apiv1.VolumeMount `json:"volumeMounts,omitempty"`
+	RestartNonce          string              `json:"restartNonce"`
+	DeleteMode            DeleteMode          `json:"deleteMode,omitempty"`
+	AllowNonRestoredState bool                `json:"allowNonRestoredState,omitempty"`
+	ForceRollback         bool                `json:"forceRollback"`
 }
 
 type FlinkConfig map[string]interface{}
@@ -158,19 +158,19 @@ type FlinkJobStatus struct {
 }
 
 type FlinkApplicationStatus struct {
-	Phase            FlinkApplicationPhase  `json:"phase"`
-	StartedAt        *metav1.Time           `json:"startedAt,omitempty"`
-	LastUpdatedAt    *metav1.Time           `json:"lastUpdatedAt,omitempty"`
-	Reason           string                 `json:"reason,omitempty"`
-	ClusterStatus    FlinkClusterStatus     `json:"clusterStatus,omitempty"`
-	JobStatus        FlinkJobStatus         `json:"jobStatus"`
-	FailedDeployHash string                 `json:"failedDeployHash,omitEmpty"`
-	RollbackHash     string                 `json:"rollbackHash,omitEmpty"`
-	DeployHash       string                 `json:"deployHash"`
-	SavepointTriggerID string `json:"savepointTriggerId,omitempty"`
-	SavepointPath string `json:"savepointPath,omitempty"`
-	RetryCount       int32                  `json:"retryCount,omitEmpty"`
-	LastSeenError    *FlinkApplicationError `json:"lastSeenError,omitEmpty"`
+	Phase              FlinkApplicationPhase  `json:"phase"`
+	StartedAt          *metav1.Time           `json:"startedAt,omitempty"`
+	LastUpdatedAt      *metav1.Time           `json:"lastUpdatedAt,omitempty"`
+	Reason             string                 `json:"reason,omitempty"`
+	ClusterStatus      FlinkClusterStatus     `json:"clusterStatus,omitempty"`
+	JobStatus          FlinkJobStatus         `json:"jobStatus"`
+	FailedDeployHash   string                 `json:"failedDeployHash,omitEmpty"`
+	RollbackHash       string                 `json:"rollbackHash,omitEmpty"`
+	DeployHash         string                 `json:"deployHash"`
+	SavepointTriggerID string                 `json:"savepointTriggerId,omitempty"`
+	SavepointPath      string                 `json:"savepointPath,omitempty"`
+	RetryCount         int32                  `json:"retryCount,omitEmpty"`
+	LastSeenError      *FlinkApplicationError `json:"lastSeenError,omitEmpty"`
 }
 
 func (in *FlinkApplicationStatus) GetPhase() FlinkApplicationPhase {

--- a/pkg/apis/app/v1beta1/types.go
+++ b/pkg/apis/app/v1beta1/types.go
@@ -40,7 +40,9 @@ type FlinkApplicationSpec struct {
 	Parallelism           int32                        `json:"parallelism"`
 	EntryClass            string                       `json:"entryClass,omitempty"`
 	ProgramArgs           string                       `json:"programArgs,omitempty"`
+	// Deprecated
 	SavepointInfo         SavepointInfo                `json:"savepointInfo,omitempty"`
+	SavepointPath         string                       `json:"savepointPath,omitempty"`
 	DeploymentMode        DeploymentMode               `json:"deploymentMode,omitempty"`
 	RPCPort               *int32                       `json:"rpcPort,omitempty"`
 	BlobPort              *int32                       `json:"blobPort,omitempty"`
@@ -122,7 +124,6 @@ type EnvironmentConfig struct {
 
 type SavepointInfo struct {
 	SavepointLocation string `json:"savepointLocation,omitempty"`
-	TriggerID         string `json:"triggerId,omitempty"`
 }
 
 type FlinkClusterStatus struct {
@@ -166,6 +167,8 @@ type FlinkApplicationStatus struct {
 	FailedDeployHash string                 `json:"failedDeployHash,omitEmpty"`
 	RollbackHash     string                 `json:"rollbackHash,omitEmpty"`
 	DeployHash       string                 `json:"deployHash"`
+	SavepointTriggerID string `json:"savepointTriggerId,omitempty"`
+	SavepointPath string `json:"savepointPath,omitempty"`
 	RetryCount       int32                  `json:"retryCount,omitEmpty"`
 	LastSeenError    *FlinkApplicationError `json:"lastSeenError,omitEmpty"`
 }

--- a/pkg/controller/flink/flink_test.go
+++ b/pkg/controller/flink/flink_test.go
@@ -232,7 +232,7 @@ func TestFlinkIsServiceReadyErr(t *testing.T) {
 func TestFlinkGetSavepointStatus(t *testing.T) {
 	flinkControllerForTest := getTestFlinkController()
 	flinkApp := getFlinkTestApp()
-	flinkApp.Spec.SavepointInfo.TriggerID = "t1"
+	flinkApp.Status.SavepointTriggerID = "t1"
 
 	mockJmClient := flinkControllerForTest.flinkClient.(*clientMock.JobManagerClient)
 	mockJmClient.CheckSavepointStatusFunc = func(ctx context.Context, url string, jobID, triggerID string) (*client.SavepointResponse, error) {
@@ -428,7 +428,7 @@ func TestStartFlinkJob(t *testing.T) {
 	flinkApp.Spec.ProgramArgs = "args"
 	flinkApp.Spec.EntryClass = "class"
 	flinkApp.Spec.JarName = "jar-name"
-	flinkApp.Spec.SavepointInfo.SavepointLocation = "location//"
+	flinkApp.Spec.SavepointPath = "location//"
 	flinkApp.Spec.FlinkVersion = "1.7"
 
 	mockJmClient := flinkControllerForTest.flinkClient.(*clientMock.JobManagerClient)
@@ -446,7 +446,8 @@ func TestStartFlinkJob(t *testing.T) {
 		}, nil
 	}
 	jobID, err := flinkControllerForTest.StartFlinkJob(context.Background(), &flinkApp, "hash",
-		flinkApp.Spec.JarName, flinkApp.Spec.Parallelism, flinkApp.Spec.EntryClass, flinkApp.Spec.ProgramArgs, flinkApp.Spec.AllowNonRestoredState)
+		flinkApp.Spec.JarName, flinkApp.Spec.Parallelism, flinkApp.Spec.EntryClass, flinkApp.Spec.ProgramArgs,
+		flinkApp.Spec.AllowNonRestoredState, "location//")
 	assert.Nil(t, err)
 	assert.Equal(t, jobID, testJobID)
 }
@@ -465,7 +466,8 @@ func TestStartFlinkJobAllowNonRestoredState(t *testing.T) {
 		}, nil
 	}
 	jobID, err := flinkControllerForTest.StartFlinkJob(context.Background(), &flinkApp, "hash",
-		flinkApp.Spec.JarName, flinkApp.Spec.Parallelism, flinkApp.Spec.EntryClass, flinkApp.Spec.ProgramArgs, flinkApp.Spec.AllowNonRestoredState)
+		flinkApp.Spec.JarName, flinkApp.Spec.Parallelism, flinkApp.Spec.EntryClass, flinkApp.Spec.ProgramArgs,
+		flinkApp.Spec.AllowNonRestoredState, "")
 	assert.Nil(t, err)
 	assert.Equal(t, jobID, testJobID)
 }
@@ -480,7 +482,8 @@ func TestStartFlinkJobEmptyJobID(t *testing.T) {
 		return &client.SubmitJobResponse{}, nil
 	}
 	jobID, err := flinkControllerForTest.StartFlinkJob(context.Background(), &flinkApp, "hash",
-		flinkApp.Spec.JarName, flinkApp.Spec.Parallelism, flinkApp.Spec.EntryClass, flinkApp.Spec.ProgramArgs, flinkApp.Spec.AllowNonRestoredState)
+		flinkApp.Spec.JarName, flinkApp.Spec.Parallelism, flinkApp.Spec.EntryClass, flinkApp.Spec.ProgramArgs,
+		flinkApp.Spec.AllowNonRestoredState, "")
 	assert.EqualError(t, err, "unable to submit job: invalid job id")
 	assert.Empty(t, jobID)
 }
@@ -494,7 +497,8 @@ func TestStartFlinkJobErr(t *testing.T) {
 		return nil, errors.New("submit error")
 	}
 	jobID, err := flinkControllerForTest.StartFlinkJob(context.Background(), &flinkApp, "hash",
-		flinkApp.Spec.JarName, flinkApp.Spec.Parallelism, flinkApp.Spec.EntryClass, flinkApp.Spec.ProgramArgs, flinkApp.Spec.AllowNonRestoredState)
+		flinkApp.Spec.JarName, flinkApp.Spec.Parallelism, flinkApp.Spec.EntryClass, flinkApp.Spec.ProgramArgs,
+		flinkApp.Spec.AllowNonRestoredState, "")
 	assert.EqualError(t, err, "submit error")
 	assert.Empty(t, jobID)
 }

--- a/pkg/controller/flink/mock/mock_flink.go
+++ b/pkg/controller/flink/mock/mock_flink.go
@@ -14,7 +14,7 @@ type DeleteOldResourcesForApp func(ctx context.Context, application *v1beta1.Fli
 type CancelWithSavepointFunc func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (string, error)
 type ForceCancelFunc func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) error
 type StartFlinkJobFunc func(ctx context.Context, application *v1beta1.FlinkApplication, hash string,
-	jarName string, parallelism int32, entryClass string, programArgs string, allowNonRestoredState bool) (string, error)
+	jarName string, parallelism int32, entryClass string, programArgs string, allowNonRestoredState bool, savepointPath string) (string, error)
 type GetSavepointStatusFunc func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (*client.SavepointResponse, error)
 type IsClusterReadyFunc func(ctx context.Context, application *v1beta1.FlinkApplication) (bool, error)
 type IsServiceReadyFunc func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (bool, error)
@@ -79,9 +79,9 @@ func (m *FlinkController) ForceCancel(ctx context.Context, application *v1beta1.
 }
 
 func (m *FlinkController) StartFlinkJob(ctx context.Context, application *v1beta1.FlinkApplication, hash string,
-	jarName string, parallelism int32, entryClass string, programArgs string, allowNonRestoredState bool) (string, error) {
+	jarName string, parallelism int32, entryClass string, programArgs string, allowNonRestoredState bool, savepointPath string) (string, error) {
 	if m.StartFlinkJobFunc != nil {
-		return m.StartFlinkJobFunc(ctx, application, hash, jarName, parallelism, entryClass, programArgs, allowNonRestoredState)
+		return m.StartFlinkJobFunc(ctx, application, hash, jarName, parallelism, entryClass, programArgs, allowNonRestoredState, savepointPath)
 	}
 	return "", nil
 }

--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -549,7 +549,8 @@ func (s *FlinkStateMachine) handleRollingBack(ctx context.Context, app *v1beta1.
 
 	if jobID != "" {
 		app.Status.JobStatus.JobID = jobID
-		app.Spec.SavepointInfo = v1beta1.SavepointInfo{}
+		app.Status.SavepointPath = ""
+		app.Status.SavepointTriggerID = ""
 		// move to the deploy failed state
 		return s.deployFailed(ctx, app)
 	}
@@ -664,8 +665,8 @@ func (s *FlinkStateMachine) handleApplicationDeleting(ctx context.Context, app *
 		return applicationUnchanged, err
 	}
 
-	if jobFinished(job) {
-		// there are no running jobs for this application, we can just tear down
+	if app.Status.SavepointTriggerID == "" && jobFinished(job) {
+		// there are no running jobs for this application and we've completed savepointing, we can just tear down
 		return s.clearFinalizers(app)
 	}
 

--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -462,7 +462,7 @@ func (s *FlinkStateMachine) handleSubmittingJob(ctx context.Context, app *v1beta
 			// this is the first deploy, use the user-provided savepoint
 			savepointPath = app.Spec.SavepointPath
 			if savepointPath == "" {
-				// fall back to the old config for backwards-compatibility
+				//nolint // fall back to the old config for backwards-compatibility
 				savepointPath = app.Spec.SavepointInfo.SavepointLocation
 			}
 		} else {

--- a/pkg/controller/flinkapplication/flink_state_machine_test.go
+++ b/pkg/controller/flinkapplication/flink_state_machine_test.go
@@ -211,11 +211,10 @@ func TestHandleApplicationSavepointingFailed(t *testing.T) {
 	}
 
 	app := v1beta1.FlinkApplication{
-		Spec: v1beta1.FlinkApplicationSpec{
-		},
+		Spec: v1beta1.FlinkApplicationSpec{},
 		Status: v1beta1.FlinkApplicationStatus{
-			Phase:      v1beta1.FlinkApplicationSavepointing,
-			DeployHash: "blah",
+			Phase:              v1beta1.FlinkApplicationSavepointing,
+			DeployHash:         "blah",
 			SavepointTriggerID: "trigger",
 		},
 	}
@@ -239,11 +238,10 @@ func TestRestoreFromExternalizedCheckpoint(t *testing.T) {
 	updateInvoked := false
 
 	app := v1beta1.FlinkApplication{
-		Spec: v1beta1.FlinkApplicationSpec{
-		},
+		Spec: v1beta1.FlinkApplicationSpec{},
 		Status: v1beta1.FlinkApplicationStatus{
-			Phase:      v1beta1.FlinkApplicationSavepointing,
-			DeployHash: "blah",
+			Phase:              v1beta1.FlinkApplicationSavepointing,
+			DeployHash:         "blah",
 			SavepointTriggerID: "trigger",
 		},
 	}
@@ -492,8 +490,8 @@ func TestRollingBack(t *testing.T) {
 			ProgramArgs: "--test",
 		},
 		Status: v1beta1.FlinkApplicationStatus{
-			Phase:      v1beta1.FlinkApplicationRollingBackJob,
-			DeployHash: "old-hash",
+			Phase:         v1beta1.FlinkApplicationRollingBackJob,
+			DeployHash:    "old-hash",
 			SavepointPath: "file:///savepoint",
 			JobStatus: v1beta1.FlinkJobStatus{
 				JarName:     "old-job.jar",

--- a/pkg/controller/flinkapplication/flink_state_machine_test.go
+++ b/pkg/controller/flinkapplication/flink_state_machine_test.go
@@ -770,6 +770,7 @@ func TestDeleteWithSavepointAndFinishedJob(t *testing.T) {
 		Status: v1beta1.FlinkApplicationStatus{
 			Phase:      v1beta1.FlinkApplicationDeleting,
 			DeployHash: "deployhash",
+			SavepointPath: "file:///savepoint",
 			JobStatus: v1beta1.FlinkJobStatus{
 				JobID: jobID,
 			},

--- a/pkg/controller/flinkapplication/flink_state_machine_test.go
+++ b/pkg/controller/flinkapplication/flink_state_machine_test.go
@@ -223,7 +223,7 @@ func TestHandleApplicationSavepointingFailed(t *testing.T) {
 	mockK8Cluster := stateMachineForTest.k8Cluster.(*k8mock.K8Cluster)
 	mockK8Cluster.UpdateStatusFunc = func(ctx context.Context, object runtime.Object) error {
 		application := object.(*v1beta1.FlinkApplication)
-		assert.Empty(t, application.Spec.SavepointInfo.SavepointLocation)
+		assert.Empty(t, application.Status.SavepointPath)
 		assert.Equal(t, hash, application.Status.FailedDeployHash)
 		assert.Equal(t, v1beta1.FlinkApplicationDeployFailed, application.Status.Phase)
 		updateInvoked = true

--- a/pkg/controller/k8/mock/mock_k8.go
+++ b/pkg/controller/k8/mock/mock_k8.go
@@ -13,6 +13,7 @@ type CreateK8ObjectFunc func(ctx context.Context, object runtime.Object) error
 type GetServiceFunc func(ctx context.Context, namespace string, name string) (*corev1.Service, error)
 type GetServiceWithLabelFunc func(ctx context.Context, namespace string, labelMap map[string]string) (*corev1.ServiceList, error)
 type UpdateK8ObjectFunc func(ctx context.Context, object runtime.Object) error
+type UpdateStatusFunc func(ctx context.Context, object runtime.Object) error
 type DeleteK8ObjectFunc func(ctx context.Context, object runtime.Object) error
 
 type K8Cluster struct {
@@ -21,6 +22,7 @@ type K8Cluster struct {
 	GetServicesWithLabelFunc    GetServiceWithLabelFunc
 	CreateK8ObjectFunc          CreateK8ObjectFunc
 	UpdateK8ObjectFunc          UpdateK8ObjectFunc
+	UpdateStatusFunc            UpdateStatusFunc
 	DeleteK8ObjectFunc          DeleteK8ObjectFunc
 }
 
@@ -55,6 +57,13 @@ func (m *K8Cluster) CreateK8Object(ctx context.Context, object runtime.Object) e
 func (m *K8Cluster) UpdateK8Object(ctx context.Context, object runtime.Object) error {
 	if m.UpdateK8ObjectFunc != nil {
 		return m.UpdateK8ObjectFunc(ctx, object)
+	}
+	return nil
+}
+
+func (m *K8Cluster) UpdateStatus(ctx context.Context, object runtime.Object) error {
+	if m.UpdateStatusFunc != nil {
+		return m.UpdateStatusFunc(ctx, object)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR enables the [status subresource](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#status-subresource) for the FlinkApplication CRD. This makes it harder for users to accidentally overwrite status fields while trying to update their applications (an issue we've seen internally). For CRDs with the status subresource enabled, updates to the base resource will ignore changes to the status subrecord, and updates the status subresource will ignore changes to the spec and metadata.

The bulk of this PR is a set of changes that enables that one. Previously, the operator would modify the `SavepointInfo` field of the spec during updates. This goes against the general principle that the user should own the spec, and prevented a move to the status subresource as the operator would need to update both the spec and status.

Instead, we introduce a new field `spec.savepointPath` that contains the savepoint that will be restored on the initial job submission (the existing `spec.savepointInfo.savepointLocation` is retained for backwards-compatibility, but will be removed in a future CRD version). Then we introduce two new fields on the status: `status.savepointPath` (which contains the path of the savepoint that the operator has created during the update process) and `status.savepointTrigger` (which contains the trigger for the savepoint the operator is creating). This allows us to cleanly separate out user intent (which savepoint should we initially start from) from the operator's internal state and processes.

**Note**: this change is slightly incompatible with the existing operator. This update should not be deployed to a cluster where there are active flinkapplication updates occurring — i.e., all flinkapplications should be in a Running or DeployFailed state.