### PR TITLE
Fix the wordcount example Flink config

### DIFF
--- a/examples/wordcount/flink-conf.yaml
+++ b/examples/wordcount/flink-conf.yaml
@@ -3,8 +3,9 @@ jobmanager.web.log.path: /var/log/jobmanager/current
 
 taskmanager.log.path: /var/log/taskmanager/current
 taskmanager.exit-on-fatal-akka-error: true
+taskmanager.network.memory.min: 27748736
 taskmanager.network.memory.max: 2147483648
-taskmanager.network.memory.fraction: 0.125
+taskmanager.network.memory.fraction: 0.1
 
 web.upload.dir: /opt/flink
 


### PR DESCRIPTION
If I get a +1, will create and push image to dockerhub, and update the custom resource
Tested locally:

```NAME                                           READY   STATUS    RESTARTS   AGE
kubecon-example-3d0dcfc7-jm-6b97cb766b-vmtwz   1/1     Running   0          2m20s
kubecon-example-3d0dcfc7-tm-dd9fd9c75-bzdmc    1/1     Running   0          2m20s
kubecon-example-3d0dcfc7-tm-dd9fd9c75-sf4hj    1/1     Running   0          2m20s


2019-11-21 19:44:33,630 INFO  org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable      - Free slot TaskSlot(index:0, state:ACTIVE, resource profile: ResourceProfile{cpuCores=1.7976931348623157E308, heapMemoryInMB=2147483647, directMemoryInMB=2147483647, nativeMemoryInMB=2147483647, networkMemoryInMB=2147483647}, allocationId: 394c327efe5cb48ead40e564a327a26c, jobId: 389bd8c8a51b4338100051241455dfe7).
```
