### PR TITLE
Add init container

### DIFF
--- a/pkg/apis/app/v1alpha1/types.go
+++ b/pkg/apis/app/v1alpha1/types.go
@@ -46,6 +46,8 @@ type FlinkApplicationSpec struct {
 	QueryPort             *int32                       `json:"queryPort,omitempty"`
 	UIPort                *int32                       `json:"uiPort,omitempty"`
 	MetricsQueryPort      *int32                       `json:"metricsQueryPort,omitempty"`
+	InitContainerImage    string                       `json:"initContainerImageRepository"`
+	InitArgs		      []string                     `json:ArgsForInitContainer`
 	Volumes               []apiv1.Volume               `json:"volumes,omitempty"`
 	VolumeMounts          []apiv1.VolumeMount          `json:"volumeMounts,omitempty"`
 	RestartNonce          string                       `json:"restartNonce"`

--- a/pkg/apis/app/v1beta1/types.go
+++ b/pkg/apis/app/v1beta1/types.go
@@ -49,6 +49,8 @@ type FlinkApplicationSpec struct {
 	QueryPort             *int32              `json:"queryPort,omitempty"`
 	UIPort                *int32              `json:"uiPort,omitempty"`
 	MetricsQueryPort      *int32              `json:"metricsQueryPort,omitempty"`
+	InitContainerImage    string              `json:"initContainerImageRepository"`
+	InitArgs		      []string            `json:ArgsForInitContainer`
 	Volumes               []apiv1.Volume      `json:"volumes,omitempty"`
 	VolumeMounts          []apiv1.VolumeMount `json:"volumeMounts,omitempty"`
 	RestartNonce          string              `json:"restartNonce"`

--- a/pkg/apis/app/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/app/v1beta1/zz_generated.deepcopy.go
@@ -157,6 +157,11 @@ func (in *FlinkApplicationSpec) DeepCopyInto(out *FlinkApplicationSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.InitArgs != nil {
+		in, out := &in.InitArgs, &out.InitArgs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]v1.Volume, len(*in))


### PR DESCRIPTION
Run 'make generate' after modified the types.go. What I am expecting is auto generating the crd.yaml file that has the fields added/deleted correspond to types.go. I don't know why it only changed the 'zz_generated.deepcopy.go'. Thank you!