### PR TITLE
Fixes to ensure Delete phase is always handled and prevent deploys from being stuck in a Savepointing phase

### DIFF
--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -160,7 +160,7 @@ func (s *FlinkStateMachine) handle(ctx context.Context, application *v1beta1.Fli
 		return statusChanged, nil
 	}
 
-	if s.IsTimeToHandlePhase(application) {
+	if s.IsTimeToHandlePhase(application, appPhase) {
 		if !v1beta1.IsRunningPhase(application.Status.Phase) {
 			logger.Infof(ctx, "Handling state for application")
 		}
@@ -193,7 +193,14 @@ func (s *FlinkStateMachine) handle(ctx context.Context, application *v1beta1.Fli
 	return updateApplication || updateLastSeenError, appErr
 }
 
-func (s *FlinkStateMachine) IsTimeToHandlePhase(application *v1beta1.FlinkApplication) bool {
+func (s *FlinkStateMachine) IsTimeToHandlePhase(application *v1beta1.FlinkApplication, phase v1beta1.FlinkApplicationPhase) bool {
+	if phase == v1beta1.FlinkApplicationDeleting {
+		// reset lastSeenError and retryCount in case the application was failing in its previous phase
+		// We always want a Deleting phase to be handled
+		application.Status.LastSeenError = nil
+		application.Status.RetryCount = 0
+		return true
+	}
 	lastSeenError := application.Status.LastSeenError
 	if application.Status.LastSeenError == nil || !s.retryHandler.IsErrorRetryable(application.Status.LastSeenError) {
 		return true
@@ -312,12 +319,18 @@ func (s *FlinkStateMachine) handleApplicationSavepointing(ctx context.Context, a
 
 	// check the savepoints in progress
 	savepointStatusResponse, err := s.flinkController.GetSavepointStatus(ctx, application, application.Status.DeployHash)
-	if err != nil {
+	// Here shouldRollback() is used as a proxy to identify if we have exhausted all retries trying to GetSavepointStatus
+	// The application is NOT actually rolled back  because we're in a spot where there's no application running and we don't
+	// have information on the last successful savepoint.
+	// In the event that rollback evaluates to True, we don't return immediately but allow for the remaining steps to proceed as normal.
+	rollback, _ := s.shouldRollback(ctx, application)
+
+	if err != nil && !rollback {
 		return statusUnchanged, err
 	}
 
 	var restorePath string
-	if savepointStatusResponse.Operation.Location == "" &&
+	if savepointStatusResponse != nil && savepointStatusResponse.Operation.Location == "" &&
 		savepointStatusResponse.SavepointStatus.Status != client.SavePointInProgress {
 		// Savepointing failed
 		// TODO: we should probably retry this a few times before failing
@@ -340,7 +353,7 @@ func (s *FlinkStateMachine) handleApplicationSavepointing(ctx context.Context, a
 				path, flink.HashForApplication(application)))
 
 		restorePath = path
-	} else if savepointStatusResponse.SavepointStatus.Status == client.SavePointCompleted {
+	} else if savepointStatusResponse != nil && savepointStatusResponse.SavepointStatus.Status == client.SavePointCompleted {
 		s.flinkController.LogEvent(ctx, application, corev1.EventTypeNormal, "CanceledJob",
 			fmt.Sprintf("Canceled job with savepoint %s",
 				savepointStatusResponse.Operation.Location))

--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -329,9 +329,11 @@ func (s *FlinkStateMachine) handleApplicationSavepointing(ctx context.Context, a
 		return statusUnchanged, err
 	}
 
-	s.flinkController.LogEvent(ctx, application, corev1.EventTypeWarning, "SavepointStatusCheckFailed",
-		fmt.Sprintf("Exhausted retries trying to get status for savepoint for job %s: %v",
-			application.Status.JobStatus.JobID, reason))
+	if err != nil && rollback {
+		s.flinkController.LogEvent(ctx, application, corev1.EventTypeWarning, "SavepointStatusCheckFailed",
+			fmt.Sprintf("Exhausted retries trying to get status for savepoint for job %s: %v",
+				application.Status.JobStatus.JobID, reason))
+	}
 
 	var restorePath string
 	if savepointStatusResponse != nil && savepointStatusResponse.Operation.Location == "" &&

--- a/pkg/controller/flinkapplication/flink_state_machine_test.go
+++ b/pkg/controller/flinkapplication/flink_state_machine_test.go
@@ -1265,7 +1265,7 @@ func TestLastSeenErrTimeIsNil(t *testing.T) {
 }
 
 func TestCheckSavepointStatusFailing(t *testing.T) {
-	oldHash := "old-hash-force-nil"
+	oldHash := "old-hash-fail"
 	maxRetries := int32(1)
 	retryableErr := client.GetRetryableError(errors.New("blah"), "CheckSavepointStatus", "FAILED", 1)
 	app := v1beta1.FlinkApplication{
@@ -1327,7 +1327,6 @@ func TestCheckSavepointStatusFailing(t *testing.T) {
 }
 
 func TestDeleteWhenCheckSavepointStatusFailing(t *testing.T) {
-	oldHash := "old-hash"
 	retryableErr := client.GetRetryableError(errors.New("blah"), "CheckSavepointStatus", "FAILED", 1)
 	app := v1beta1.FlinkApplication{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1342,7 +1341,7 @@ func TestDeleteWhenCheckSavepointStatusFailing(t *testing.T) {
 		},
 		Status: v1beta1.FlinkApplicationStatus{
 			Phase:              v1beta1.FlinkApplicationSavepointing,
-			DeployHash:         oldHash,
+			DeployHash:         "appHash",
 			LastSeenError:      retryableErr.(*v1beta1.FlinkApplicationError),
 			SavepointTriggerID: "trigger",
 		},
@@ -1376,7 +1375,7 @@ func TestDeleteWhenCheckSavepointStatusFailing(t *testing.T) {
 	app.Spec.DeleteMode = v1beta1.DeleteModeForceCancel
 
 	mockFlinkController.GetJobForApplicationFunc = func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (*client.FlinkJobOverview, error) {
-		assert.Equal(t, "old-hash", hash)
+		assert.Equal(t, "appHash", hash)
 		return &client.FlinkJobOverview{
 			JobID: "jobID",
 			State: client.Failing,

--- a/pkg/controller/flinkapplication/flink_state_machine_test.go
+++ b/pkg/controller/flinkapplication/flink_state_machine_test.go
@@ -1263,3 +1263,131 @@ func TestLastSeenErrTimeIsNil(t *testing.T) {
 	assert.Nil(t, err)
 
 }
+
+func TestCheckSavepointStatusFailing(t *testing.T) {
+	oldHash := "old-hash-force-nil"
+	maxRetries := int32(1)
+	retryableErr := client.GetRetryableError(errors.New("blah"), "CheckSavepointStatus", "FAILED", 1)
+	app := v1beta1.FlinkApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-app",
+			Namespace: "flink",
+		},
+		Spec: v1beta1.FlinkApplicationSpec{
+			JarName:     "job.jar",
+			Parallelism: 5,
+			EntryClass:  "com.my.Class",
+			ProgramArgs: "--test",
+		},
+		Status: v1beta1.FlinkApplicationStatus{
+			Phase:              v1beta1.FlinkApplicationSavepointing,
+			DeployHash:         oldHash,
+			LastSeenError:      retryableErr.(*v1beta1.FlinkApplicationError),
+			SavepointTriggerID: "trigger",
+		},
+	}
+	app.Status.LastSeenError.LastErrorUpdateTime = nil
+
+	stateMachineForTest := getTestStateMachine()
+	mockFlinkController := stateMachineForTest.flinkController.(*mock.FlinkController)
+	mockFlinkController.GetSavepointStatusFunc = func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (*client.SavepointResponse, error) {
+		return &client.SavepointResponse{
+			SavepointStatus: client.SavepointStatusResponse{
+				Status: client.SavePointInvalid,
+			},
+			Operation: client.SavepointOperationResponse{
+				Location: "",
+			}}, retryableErr.(*v1beta1.FlinkApplicationError)
+	}
+
+	mockFlinkController.FindExternalizedCheckpointFunc = func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (string, error) {
+		return "/tmp/checkpoint", nil
+	}
+	mockRetryHandler := stateMachineForTest.retryHandler.(*mock.RetryHandler)
+	mockRetryHandler.IsErrorRetryableFunc = func(err error) bool {
+		return true
+	}
+	mockRetryHandler.IsTimeToRetryFunc = func(clock clock.Clock, lastUpdatedTime time.Time, retryCount int32) bool {
+		return true
+	}
+	mockRetryHandler.IsRetryRemainingFunc = func(err error, retryCount int32) bool {
+		return retryCount < maxRetries
+	}
+
+	err := stateMachineForTest.Handle(context.Background(), &app)
+	// 1 retry left
+	assert.NotNil(t, err)
+	assert.Equal(t, v1beta1.FlinkApplicationSavepointing, app.Status.Phase)
+
+	// No retries left for CheckSavepointStatus
+	// The app should hence try to recover from an externalized checkpoint
+	err = stateMachineForTest.Handle(context.Background(), &app)
+	assert.Nil(t, err)
+	assert.Equal(t, v1beta1.FlinkApplicationSubmittingJob, app.Status.Phase)
+}
+
+func TestDeleteWhenCheckSavepointStatusFailing(t *testing.T) {
+	oldHash := "old-hash"
+	retryableErr := client.GetRetryableError(errors.New("blah"), "CheckSavepointStatus", "FAILED", 1)
+	app := v1beta1.FlinkApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-app",
+			Namespace: "flink",
+		},
+		Spec: v1beta1.FlinkApplicationSpec{
+			JarName:     "job.jar",
+			Parallelism: 5,
+			EntryClass:  "com.my.Class",
+			ProgramArgs: "--test",
+		},
+		Status: v1beta1.FlinkApplicationStatus{
+			Phase:              v1beta1.FlinkApplicationSavepointing,
+			DeployHash:         oldHash,
+			LastSeenError:      retryableErr.(*v1beta1.FlinkApplicationError),
+			SavepointTriggerID: "trigger",
+		},
+	}
+	app.Status.LastSeenError.LastErrorUpdateTime = nil
+
+	stateMachineForTest := getTestStateMachine()
+	mockFlinkController := stateMachineForTest.flinkController.(*mock.FlinkController)
+	mockFlinkController.GetSavepointStatusFunc = func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (*client.SavepointResponse, error) {
+		return &client.SavepointResponse{
+			SavepointStatus: client.SavepointStatusResponse{
+				Status: client.SavePointInvalid,
+			},
+			Operation: client.SavepointOperationResponse{
+				Location: "",
+			}}, retryableErr.(*v1beta1.FlinkApplicationError)
+	}
+	mockRetryHandler := stateMachineForTest.retryHandler.(*mock.RetryHandler)
+	mockRetryHandler.IsErrorRetryableFunc = func(err error) bool {
+		return true
+	}
+	mockRetryHandler.IsRetryRemainingFunc = func(err error, retryCount int32) bool {
+		return true
+	}
+	err := stateMachineForTest.Handle(context.Background(), &app)
+	assert.NotNil(t, err)
+	assert.Equal(t, v1beta1.FlinkApplicationSavepointing, app.Status.Phase)
+	// Try to force delete the app while it's in a savepointing state (with errors)
+	// We should handle the delete here
+	app.Status.Phase = v1beta1.FlinkApplicationDeleting
+	app.Spec.DeleteMode = v1beta1.DeleteModeForceCancel
+
+	mockFlinkController.GetJobForApplicationFunc = func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) (*client.FlinkJobOverview, error) {
+		assert.Equal(t, "old-hash", hash)
+		return &client.FlinkJobOverview{
+			JobID: "jobID",
+			State: client.Failing,
+		}, nil
+	}
+
+	mockFlinkController.ForceCancelFunc = func(ctx context.Context, application *v1beta1.FlinkApplication, hash string) error {
+		return nil
+	}
+	err = stateMachineForTest.Handle(context.Background(), &app)
+	assert.Nil(t, err)
+	assert.Nil(t, app.GetFinalizers())
+
+}

--- a/pkg/controller/flinkapplication/flink_state_machine_test.go
+++ b/pkg/controller/flinkapplication/flink_state_machine_test.go
@@ -1369,6 +1369,7 @@ func TestDeleteWhenCheckSavepointStatusFailing(t *testing.T) {
 	err := stateMachineForTest.Handle(context.Background(), &app)
 	assert.NotNil(t, err)
 	assert.Equal(t, v1beta1.FlinkApplicationSavepointing, app.Status.Phase)
+	assert.NotNil(t, app.Status.LastSeenError)
 	// Try to force delete the app while it's in a savepointing state (with errors)
 	// We should handle the delete here
 	app.Status.Phase = v1beta1.FlinkApplicationDeleting
@@ -1387,6 +1388,8 @@ func TestDeleteWhenCheckSavepointStatusFailing(t *testing.T) {
 	}
 	err = stateMachineForTest.Handle(context.Background(), &app)
 	assert.Nil(t, err)
+	assert.Nil(t, app.Status.LastSeenError)
+	assert.Equal(t, int32(0), app.Status.RetryCount)
 	assert.Nil(t, app.GetFinalizers())
 
 }


### PR DESCRIPTION
**Problem** 
- Deploy starts — Savepoint is triggered and triggerID registered
- `GetSavepointStatus` call keeps failing for whatever reason
-  Retries are exhausted for `GetSavepointStatus`, however we have[ no real way to progress ](https://github.com/lyft/flinkk8soperator/blob/master/pkg/controller/flinkapplication/flink_state_machine.go#L315)after this. The app gets stuck in a Savepointing Phase.
- User tries to force delete the application. However, with retry counts not being reset and a non-nil LastSeenError, the operator never handles the Deleting phase (i.e. [isTimeToHandlePhase](https://github.com/lyft/flinkk8soperator/blob/master/pkg/controller/flinkapplication/flink_state_machine.go#L196) always evaluates to false).

The PR fixes these problems in the following way:
- Reduces retries for the GetSavepointStatus call from 20 --> 3 to reduce the time to detect savepoint failures (esp. 404s around savepoints not being found for a triggerID). I considered making this non-retryable, but I'm guessing there's a possibility that the savepoint status for a triggerID may not become immediately available. 
- When retries for GetSavepointStatus are exhausted, we cannot reliably rollback at this point, as we may not have a running job or a successful savepoint. So we allow for the remainder of the savepointing block to complete i.e. try to recover from an externalized checkpoint. 
- When a Delete is attempted, always handle the Deleting phase irrespective of what error/retry state the application is in. 