### PR TITLE
Add missing dot to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ FlinkK8sOperator is a [Kubernetes operator](https://coreos.com/operators/) that 
 
 *Beta*
 
-The operator is in use for some less-critical jobs at Lyft. At this point the focus is on testing and stability While in 
+The operator is in use for some less-critical jobs at Lyft. At this point the focus is on testing and stability. While in 
 Beta, we will attempt to limit the number of backwards-incompatible changes, but they may still occur as necessary. 
 
 ## Prerequisites


### PR DESCRIPTION
tiny fix -- looks like a dot's missing in the project status section: `... and stability. While in Beta, ...` 