### PR TITLE
[STRMCMP-771] Properly initialize http client to fix multiple submission issue

### DIFF
--- a/pkg/controller/flink/client/api.go
+++ b/pkg/controller/flink/client/api.go
@@ -157,7 +157,7 @@ func (c *FlinkJobManagerClient) GetClusterOverview(ctx context.Context, url stri
 // Helper method to execute the requests
 func (c *FlinkJobManagerClient) executeRequest(ctx context.Context,
 	method string, url string, payload interface{}) (*resty.Response, error) {
-	client := resty.SetLogger(logger.GetLogWriter(ctx)).SetTimeout(defaultTimeOut)
+	client := resty.New().SetLogger(logger.GetLogWriter(ctx)).SetTimeout(defaultTimeOut)
 
 	var resp *resty.Response
 	var err error

--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -542,7 +542,7 @@ func (s *FlinkStateMachine) handleRollingBack(ctx context.Context, app *v1beta1.
 		// we've failed in our roll back attempt (presumably because something's now wrong with the original cluster)
 		// move immediately to the DeployFailed state so that the user can recover.
 		s.flinkController.LogEvent(ctx, app, corev1.EventTypeWarning, "RollbackFailed",
-			fmt.Sprintf("Failed to rollback to origin deployment, manual intervention needed: %s", reason))
+			fmt.Sprintf("Failed to rollback to original deployment, manual intervention needed: %s", reason))
 		return s.deployFailed(ctx, app)
 	}
 


### PR DESCRIPTION
This fixes a bug that could lead to multiple job submissions in cases where there was an http-connection level error (e.g., a timeout).

Previously we were not calling `New()` on the resty package, which meant that we were using a single instance of the resty client across all calls. The meant that when we configured it for any call, the same configuration was used for subsequent calls. In particular, that meant that once we did a Get call, setting the number of retries to 3, that policy was applied to all subsequent calls, including POSTs, which should never be automatically retried. When a timeout occurred, this could then lead to multiple job submissions as the POST request was retried.