### PR TITLE
Add status subresource permission for Operator

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -64,6 +64,7 @@ rules:
    - flink.k8s.io
    resources:
    - flinkapplications
+   - flinkapplications/status
    - flinkapplications/finalizers
    verbs:
    - get


### PR DESCRIPTION
```
{"json":{"app_name":"wordcount-operator-example","ns":"team1","phase":""},"level":"error","msg":"K8s object update failed flinkapplications.flink.k8s.io \"wordcount-operator-example\" is forbidden: User \"system:serviceaccount:flink-operator:flinkoperator\" cannot update resource \"flinkapplications/status\" in API group \"flink.k8s.io\" in the namespace \"team1\"",
"ts":"2020-01-17T16:38:34Z"}
```

related to https://github.com/lyft/flinkk8soperator/issues/161