### PR TITLE
[STRMCMP-825] Improve error messaging when moving to DeployFailed in a non-recoverable state

### DIFF
--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -298,7 +298,6 @@ func (s *FlinkStateMachine) handleApplicationSavepointing(ctx context.Context, a
 		s.flinkController.LogEvent(ctx, application, corev1.EventTypeWarning, "SavepointFailed",
 			fmt.Sprintf("Could not savepoint existing job: %s", reason))
 		application.Status.RetryCount = 0
-		application.Status.JobStatus.JobID = ""
 		s.updateApplicationPhase(application, v1beta1.FlinkApplicationRecovering)
 		return statusChanged, nil
 	}

--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -231,7 +231,7 @@ func (s *FlinkStateMachine) handleNewOrUpdating(ctx context.Context, application
 		// we've failed to make progress; move to deploy failed
 		s.flinkController.LogEvent(ctx, application, corev1.EventTypeWarning, "ClusterCreationFailed",
 			fmt.Sprintf("Failed to create Flink Cluster: %s", reason))
-		return s.deployFailed(ctx, application)
+		return s.deployFailed(application)
 	}
 
 	// Create the Flink cluster
@@ -245,10 +245,8 @@ func (s *FlinkStateMachine) handleNewOrUpdating(ctx context.Context, application
 	return statusChanged, nil
 }
 
-func (s *FlinkStateMachine) deployFailed(ctx context.Context, app *v1beta1.FlinkApplication) (bool, error) {
+func (s *FlinkStateMachine) deployFailed(app *v1beta1.FlinkApplication) (bool, error) {
 	hash := flink.HashForApplication(app)
-	s.flinkController.LogEvent(ctx, app, corev1.EventTypeWarning, "RolledBackDeploy",
-		fmt.Sprintf("Successfully rolled back deploy %s", hash))
 	app.Status.FailedDeployHash = hash
 	// set rollbackHash to deployHash
 	app.Status.RollbackHash = app.Status.DeployHash
@@ -268,7 +266,7 @@ func (s *FlinkStateMachine) handleClusterStarting(ctx context.Context, applicati
 		s.flinkController.LogEvent(ctx, application, corev1.EventTypeWarning, "ClusterCreationFailed",
 			fmt.Sprintf(
 				"Flink cluster failed to become available: %s", reason))
-		return s.deployFailed(ctx, application)
+		return s.deployFailed(application)
 	}
 
 	// Wait for all to be running
@@ -292,7 +290,6 @@ func (s *FlinkStateMachine) handleClusterStarting(ctx context.Context, applicati
 func (s *FlinkStateMachine) handleApplicationSavepointing(ctx context.Context, application *v1beta1.FlinkApplication) (bool, error) {
 	// we've already savepointed (or this is our first deploy), continue on
 	if application.Status.SavepointPath != "" || application.Status.DeployHash == "" {
-		application.Status.JobStatus.JobID = ""
 		s.updateApplicationPhase(application, v1beta1.FlinkApplicationSubmittingJob)
 		return statusChanged, nil
 	}
@@ -301,6 +298,7 @@ func (s *FlinkStateMachine) handleApplicationSavepointing(ctx context.Context, a
 		s.flinkController.LogEvent(ctx, application, corev1.EventTypeWarning, "SavepointFailed",
 			fmt.Sprintf("Could not savepoint existing job: %s", reason))
 		application.Status.RetryCount = 0
+		application.Status.JobStatus.JobID = ""
 		s.updateApplicationPhase(application, v1beta1.FlinkApplicationRecovering)
 		return statusChanged, nil
 	}
@@ -366,11 +364,16 @@ func (s *FlinkStateMachine) handleApplicationRecovering(ctx context.Context, app
 	// try to find an externalized checkpoint
 	path, err := s.flinkController.FindExternalizedCheckpoint(ctx, app, app.Status.DeployHash)
 	if err != nil {
-		logger.Infof(ctx, "error while fetching externalized checkpoint path: %v", err)
-		return s.deployFailed(ctx, app)
+		s.flinkController.LogEvent(ctx, app, corev1.EventTypeWarning, "RecoveryFailed",
+			"Failed to get externalized checkpoint config, could not recover. "+
+				"Manual intervention is needed.")
+		return s.deployFailed(app)
 	} else if path == "" {
-		logger.Infof(ctx, "no externalized checkpoint found")
-		return s.deployFailed(ctx, app)
+		s.flinkController.LogEvent(ctx, app, corev1.EventTypeWarning, "RecoveryFailed",
+			"No externalized checkpoint found, could not recover. Make sure that "+
+				"externalized checkpoints are enabled in your job's checkpoint configuration. Manual intervention "+
+				"is needed to recover.")
+		return s.deployFailed(app)
 	}
 
 	s.flinkController.LogEvent(ctx, app, corev1.EventTypeNormal, "RestoringExternalizedCheckpoint",
@@ -512,6 +515,9 @@ func (s *FlinkStateMachine) handleSubmittingJob(ctx context.Context, app *v1beta
 	if err != nil {
 		return statusUnchanged, err
 	}
+	if job == nil {
+		return statusUnchanged, errors.Errorf("Could not find job %s", app.Status.JobStatus.JobID)
+	}
 
 	// wait until all vertices have been scheduled and started
 	allVerticesStarted := true
@@ -545,7 +551,7 @@ func (s *FlinkStateMachine) handleRollingBack(ctx context.Context, app *v1beta1.
 		// move immediately to the DeployFailed state so that the user can recover.
 		s.flinkController.LogEvent(ctx, app, corev1.EventTypeWarning, "RollbackFailed",
 			fmt.Sprintf("Failed to rollback to original deployment, manual intervention needed: %s", reason))
-		return s.deployFailed(ctx, app)
+		return s.deployFailed(app)
 	}
 
 	s.flinkController.LogEvent(ctx, app, corev1.EventTypeWarning, "DeployFailed",
@@ -587,7 +593,9 @@ func (s *FlinkStateMachine) handleRollingBack(ctx context.Context, app *v1beta1.
 		app.Status.SavepointPath = ""
 		app.Status.SavepointTriggerID = ""
 		// move to the deploy failed state
-		return s.deployFailed(ctx, app)
+		s.flinkController.LogEvent(ctx, app, corev1.EventTypeNormal, "RollbackSucceeded",
+			"Successfully rolled back to previous deploy")
+		return s.deployFailed(app)
 	}
 
 	return statusUnchanged, nil
@@ -698,6 +706,10 @@ func (s *FlinkStateMachine) handleApplicationDeleting(ctx context.Context, app *
 	job, err := s.flinkController.GetJobForApplication(ctx, app, app.Status.DeployHash)
 	if err != nil {
 		return statusUnchanged, err
+	}
+
+	if job == nil {
+		return s.clearFinalizers(ctx, app)
 	}
 
 	switch app.Spec.DeleteMode {


### PR DESCRIPTION
Currently, all transitions to deployFailed production a `Successfully rolled back deploy` event (via the FlinkStateMachine.deployFailed method). However, there are some cases where the rollback in fact has failed; for example in the sequence where
1. cancelling the existing job succeeds, but we fail to find the savepoint path for some reason
2. there's never been a successful checkpoint taken for the job (or we fail to query it), so recovery fails

This change improves the error message in those cases to be clearer to the user that rollback has failed, and manual intervention is needed to recover.

Also includes a nil-pointer deference bug fix for the output of `GetJobForApplication`, which I encountered while reproducing this.