### PR TITLE
[STRMCMP-844] Fix rollback when SubmittingJob times out

### DIFF
--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -460,6 +460,7 @@ func (s *FlinkStateMachine) handleSubmittingJob(ctx context.Context, app *v1beta
 		// Something's gone wrong; roll back
 		s.flinkController.LogEvent(ctx, app, corev1.EventTypeWarning, "JobSubmissionFailed",
 			fmt.Sprintf("Failed to submit job: %s", reason))
+		app.Status.JobStatus.JobID = ""
 		s.updateApplicationPhase(app, v1beta1.FlinkApplicationRollingBackJob)
 		return statusChanged, nil
 	}

--- a/pkg/controller/flinkapplication/flink_state_machine_test.go
+++ b/pkg/controller/flinkapplication/flink_state_machine_test.go
@@ -1101,12 +1101,12 @@ func TestRollbackAfterJobSubmission(t *testing.T) {
 
 	stateMachineForTest := getTestStateMachine()
 
-	stateMachineForTest.Handle(context.Background(), &app)
+	err := stateMachineForTest.Handle(context.Background(), &app)
+	assert.Nil(t, err)
 
 	assert.Equal(t, v1beta1.FlinkApplicationRollingBackJob, app.Status.Phase)
 	assert.Equal(t, "", app.Status.JobStatus.JobID)
 }
-
 
 func TestErrorHandlingInRunningPhase(t *testing.T) {
 	app := v1beta1.FlinkApplication{


### PR DESCRIPTION
If we time out after the new job has been submitted (generally because the tasks are never all running, possibly due to parallelism being misconfigured), we will enter the rollback phase. However, because the new job _was_ submitted, the jobID is set in our status, and so [this check|https://github.com/lyft/flinkk8soperator/blob/4142437353666b8692e62acf075a9b2c70514dd9/pkg/controller/flinkapplication/flink_state_machine.go#L396] prevents us from submitting the job to the old cluster.

This PR fixes that issue by clearing the jobId before moving to the RollingBack phase.