### PR TITLE
ingress configuration 'ingressAnnotations' and 'ingressTLSSecretName'

### DIFF
--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -40,6 +40,12 @@ spec:
                 properties:
                   name:
                     type: string
+            ingressAnnotations:
+              description: May be used to configure the ingress objects
+              type: object
+            ingressTLSSecretName:
+              description: May be used to configure the ingress TLS
+              type: string
             serviceAccountName:
               type: string
             securityContext:

--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -98,6 +98,9 @@ metadata:
   selfLink: v1beta1
   uid: a2855178-b29c-11e9-9a3b-025000000001
 spec:
+  ingressAnnotations:
+    kubernetes.io/ingress.class: nginx
+  ingressTLSSecretName: "wordcount-secret-tls"
   entryClass: org.apache.flink.WordCount
   flinkConfig:
     state.backend.fs.checkpointdir: file:///checkpoints/flink/checkpoints

--- a/examples/beam-python/flink-operator-custom-resource.yaml
+++ b/examples/beam-python/flink-operator-custom-resource.yaml
@@ -9,6 +9,11 @@ metadata:
 spec:
   #image: docker.io/lyft/flinkk8soperator-example-beam:{sha}
   image: flinkk8soperator-example-beam
+  # Any ingress annotations can be set there
+  # ingressAnnotations:
+  #   kubernetes.io/ingress.class: nginx
+  # Declare the secret that stores the TLS key and cert
+  # ingressTLSSecretName: "tls-secret"
   flinkConfig:
     taskmanager.network.memory.fraction: 0.1
     taskmanager.network.memory.min: 10m

--- a/examples/wordcount/flink-operator-custom-resource.yaml
+++ b/examples/wordcount/flink-operator-custom-resource.yaml
@@ -2,12 +2,16 @@ apiVersion: flink.k8s.io/v1beta1
 kind: FlinkApplication
 metadata:
   name: wordcount-operator-example
-  namespace: flink-operator
   annotations:
   labels:
     environment: development
 spec:
   image: docker.io/lyft/wordcount-operator-example:{sha}
+  # Any ingress annotations can be set there
+  # ingressAnnotations:
+  #   kubernetes.io/ingress.class: nginx
+  # Declare the secret that stores the TLS key and cert
+  # ingressTLSSecretName: "tls-secret"
   deleteMode: None
   flinkConfig:
     taskmanager.heap.size: 200

--- a/pkg/apis/app/v1beta1/types.go
+++ b/pkg/apis/app/v1beta1/types.go
@@ -28,19 +28,21 @@ type FlinkApplication struct {
 }
 
 type FlinkApplicationSpec struct {
-	Image              string                       `json:"image,omitempty" protobuf:"bytes,2,opt,name=image"`
-	ImagePullPolicy    apiv1.PullPolicy             `json:"imagePullPolicy,omitempty" protobuf:"bytes,14,opt,name=imagePullPolicy,casttype=PullPolicy"`
-	ImagePullSecrets   []apiv1.LocalObjectReference `json:"imagePullSecrets,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,15,rep,name=imagePullSecrets"`
-	ServiceAccountName string                       `json:"serviceAccountName,omitempty"`
-	SecurityContext    *apiv1.PodSecurityContext    `json:"securityContext,omitempty"`
-	FlinkConfig        FlinkConfig                  `json:"flinkConfig"`
-	FlinkVersion       string                       `json:"flinkVersion"`
-	TaskManagerConfig  TaskManagerConfig            `json:"taskManagerConfig,omitempty"`
-	JobManagerConfig   JobManagerConfig             `json:"jobManagerConfig,omitempty"`
-	JarName            string                       `json:"jarName"`
-	Parallelism        int32                        `json:"parallelism"`
-	EntryClass         string                       `json:"entryClass,omitempty"`
-	ProgramArgs        string                       `json:"programArgs,omitempty"`
+	Image                string                       `json:"image,omitempty" protobuf:"bytes,2,opt,name=image"`
+	ImagePullPolicy      apiv1.PullPolicy             `json:"imagePullPolicy,omitempty" protobuf:"bytes,14,opt,name=imagePullPolicy,casttype=PullPolicy"`
+	ImagePullSecrets     []apiv1.LocalObjectReference `json:"imagePullSecrets,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,15,rep,name=imagePullSecrets"`
+	IngressAnnotations   map[string]string            `json:"ingressAnnotations,omitempty"`
+	IngressTLSSecretName string                       `json:"ingressTLSSecretName,omitempty"`
+	ServiceAccountName   string                       `json:"serviceAccountName,omitempty"`
+	SecurityContext      *apiv1.PodSecurityContext    `json:"securityContext,omitempty"`
+	FlinkConfig          FlinkConfig                  `json:"flinkConfig"`
+	FlinkVersion         string                       `json:"flinkVersion"`
+	TaskManagerConfig    TaskManagerConfig            `json:"taskManagerConfig,omitempty"`
+	JobManagerConfig     JobManagerConfig             `json:"jobManagerConfig,omitempty"`
+	JarName              string                       `json:"jarName"`
+	Parallelism          int32                        `json:"parallelism"`
+	EntryClass           string                       `json:"entryClass,omitempty"`
+	ProgramArgs          string                       `json:"programArgs,omitempty"`
 	// Deprecated: use SavepointPath instead
 	SavepointInfo                  SavepointInfo       `json:"savepointInfo,omitempty"`
 	SavepointPath                  string              `json:"savepointPath,omitempty"`

--- a/pkg/apis/app/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/app/v1beta1/zz_generated.deepcopy.go
@@ -128,6 +128,13 @@ func (in *FlinkApplicationSpec) DeepCopyInto(out *FlinkApplicationSpec) {
 		*out = make([]v1.LocalObjectReference, len(*in))
 		copy(*out, *in)
 	}
+	if in.IngressAnnotations != nil {
+		in, out := &in.IngressAnnotations, &out.IngressAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.SecurityContext != nil {
 		in, out := &in.SecurityContext, &out.SecurityContext
 		*out = new(v1.PodSecurityContext)

--- a/pkg/controller/flink/ingress.go
+++ b/pkg/controller/flink/ingress.go
@@ -27,9 +27,10 @@ func FetchJobManagerIngressCreateObj(app *flinkapp.FlinkApplication) *v1beta1.In
 	podLabels = common.CopyMap(podLabels, k8.GetAppLabel(app.Name))
 
 	ingressMeta := v1.ObjectMeta{
-		Name:      app.Name,
-		Labels:    podLabels,
-		Namespace: app.Namespace,
+		Name:        app.Name,
+		Labels:      podLabels,
+		Annotations: app.Spec.IngressAnnotations,
+		Namespace:   app.Namespace,
 		OwnerReferences: []v1.OwnerReference{
 			*v1.NewControllerRef(app, app.GroupVersionKind()),
 		},
@@ -42,7 +43,6 @@ func FetchJobManagerIngressCreateObj(app *flinkapp.FlinkApplication) *v1beta1.In
 			IntVal: getUIPort(app),
 		},
 	}
-
 	ingressSpec := v1beta1.IngressSpec{
 		Rules: []v1beta1.IngressRule{{
 			Host: GetFlinkUIIngressURL(app.Name),
@@ -54,6 +54,14 @@ func FetchJobManagerIngressCreateObj(app *flinkapp.FlinkApplication) *v1beta1.In
 				},
 			},
 		}},
+	}
+	if app.Spec.IngressTLSSecretName != "" {
+		ingressSpec.TLS = []v1beta1.IngressTLS{
+			{
+				Hosts:      []string{GetFlinkUIIngressURL(app.Name)},
+				SecretName: app.Spec.IngressTLSSecretName,
+			},
+		}
 	}
 	return &v1beta1.Ingress{
 		ObjectMeta: ingressMeta,


### PR DESCRIPTION
In order to be able to configure the ingresses this PR allows to set *annotations* and the TLS secret name to retrieve the certificates.

fixes https://github.com/lyft/flinkk8soperator/issues/131