### PR TITLE
Add service options

### DIFF
--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -40,6 +40,12 @@ spec:
                 properties:
                   name:
                     type: string
+            serviceAnnotations:
+              description: May be used to configure the service objects
+              type: object
+            serviceType:
+              description: May be used to configure the service Type
+              type: string
             serviceAccountName:
               type: string
             securityContext:

--- a/pkg/apis/app/v1beta1/types.go
+++ b/pkg/apis/app/v1beta1/types.go
@@ -33,7 +33,7 @@ type FlinkApplicationSpec struct {
 	ImagePullSecrets   []apiv1.LocalObjectReference `json:"imagePullSecrets,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,15,rep,name=imagePullSecrets"`
 	ServiceAccountName string                       `json:"serviceAccountName,omitempty"`
 	ServiceAnnotations map[string]string            `json:"serviceAnnotations,omitempty"`
-	ServiceType				 string                       `json:"serviceType,omitempty"`
+	ServiceType        string                       `json:"serviceType,omitempty"`
 	SecurityContext    *apiv1.PodSecurityContext    `json:"securityContext,omitempty"`
 	FlinkConfig        FlinkConfig                  `json:"flinkConfig"`
 	FlinkVersion       string                       `json:"flinkVersion"`

--- a/pkg/apis/app/v1beta1/types.go
+++ b/pkg/apis/app/v1beta1/types.go
@@ -32,6 +32,8 @@ type FlinkApplicationSpec struct {
 	ImagePullPolicy    apiv1.PullPolicy             `json:"imagePullPolicy,omitempty" protobuf:"bytes,14,opt,name=imagePullPolicy,casttype=PullPolicy"`
 	ImagePullSecrets   []apiv1.LocalObjectReference `json:"imagePullSecrets,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,15,rep,name=imagePullSecrets"`
 	ServiceAccountName string                       `json:"serviceAccountName,omitempty"`
+	ServiceAnnotations map[string]string            `json:"serviceAnnotations,omitempty"`
+	ServiceType				 string                       `json:"serviceType,omitempty"`
 	SecurityContext    *apiv1.PodSecurityContext    `json:"securityContext,omitempty"`
 	FlinkConfig        FlinkConfig                  `json:"flinkConfig"`
 	FlinkVersion       string                       `json:"flinkVersion"`

--- a/pkg/apis/app/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/app/v1beta1/zz_generated.deepcopy.go
@@ -128,6 +128,13 @@ func (in *FlinkApplicationSpec) DeepCopyInto(out *FlinkApplicationSpec) {
 		*out = make([]v1.LocalObjectReference, len(*in))
 		copy(*out, *in)
 	}
+	if in.ServiceAnnotations != nil {
+		in, out := &in.ServiceAnnotations, &out.ServiceAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.SecurityContext != nil {
 		in, out := &in.SecurityContext, &out.SecurityContext
 		*out = new(v1.PodSecurityContext)

--- a/pkg/controller/flink/job_manager_controller.go
+++ b/pkg/controller/flink/job_manager_controller.go
@@ -215,7 +215,7 @@ func FetchJobManagerServiceCreateObj(app *v1beta1.FlinkApplication, hash string)
 func getJobManagerServiceType(app *v1beta1.FlinkApplication) coreV1.ServiceType {
 	if app.Spec.ServiceType == "NodePort" {
 		return coreV1.ServiceTypeNodePort
-	} 
+	}
 	return coreV1.ServiceTypeClusterIP
 }
 

--- a/pkg/controller/flink/job_manager_controller.go
+++ b/pkg/controller/flink/job_manager_controller.go
@@ -196,8 +196,8 @@ func FetchJobManagerServiceCreateObj(app *v1beta1.FlinkApplication, hash string)
 			Kind:       k8.Service,
 		},
 		ObjectMeta: metaV1.ObjectMeta{
-			Name:      jmServiceName,
-			Namespace: app.Namespace,
+			Name:        jmServiceName,
+			Namespace:   app.Namespace,
 			Annotations: app.Spec.ServiceAnnotations,
 			OwnerReferences: []metaV1.OwnerReference{
 				*metaV1.NewControllerRef(app, app.GroupVersionKind()),
@@ -215,9 +215,8 @@ func FetchJobManagerServiceCreateObj(app *v1beta1.FlinkApplication, hash string)
 func getJobManagerServiceType(app *v1beta1.FlinkApplication) coreV1.ServiceType {
 	if app.Spec.ServiceType == "NodePort" {
 		return coreV1.ServiceTypeNodePort
-	} else {
-		return coreV1.ServiceTypeClusterIP
-	}
+	} 
+	return coreV1.ServiceTypeClusterIP
 }
 
 func getJobManagerServiceName(app *v1beta1.FlinkApplication) string {

--- a/pkg/controller/flink/job_manager_controller.go
+++ b/pkg/controller/flink/job_manager_controller.go
@@ -198,6 +198,7 @@ func FetchJobManagerServiceCreateObj(app *v1beta1.FlinkApplication, hash string)
 		ObjectMeta: metaV1.ObjectMeta{
 			Name:      jmServiceName,
 			Namespace: app.Namespace,
+			Annotations: app.Spec.ServiceAnnotations,
 			OwnerReferences: []metaV1.OwnerReference{
 				*metaV1.NewControllerRef(app, app.GroupVersionKind()),
 			},
@@ -206,7 +207,16 @@ func FetchJobManagerServiceCreateObj(app *v1beta1.FlinkApplication, hash string)
 		Spec: coreV1.ServiceSpec{
 			Ports:    getJobManagerServicePorts(app),
 			Selector: serviceLabels,
+			Type:     getJobManagerServiceType(app),
 		},
+	}
+}
+
+func getJobManagerServiceType(app *v1beta1.FlinkApplication) coreV1.ServiceType {
+	if app.Spec.ServiceType == "NodePort" {
+		return coreV1.ServiceTypeNodePort
+	} else {
+		return coreV1.ServiceTypeClusterIP
 	}
 }
 

--- a/pkg/controller/flinkapplication/flink_state_machine_test.go
+++ b/pkg/controller/flinkapplication/flink_state_machine_test.go
@@ -601,7 +601,7 @@ func TestRollingBack(t *testing.T) {
 			DeployHash:    "old-hash",
 			SavepointPath: "file:///savepoint",
 			VersionStatuses: []v1beta1.FlinkApplicationVersionStatus{
-				v1beta1.FlinkApplicationVersionStatus{
+				{
 					JobStatus: v1beta1.FlinkJobStatus{
 						JarName:     "old-job.jar",
 						Parallelism: 10,
@@ -784,7 +784,7 @@ func TestDeleteWithSavepoint(t *testing.T) {
 			Phase:      v1beta1.FlinkApplicationDeleting,
 			DeployHash: "deployhash",
 			VersionStatuses: []v1beta1.FlinkApplicationVersionStatus{
-				v1beta1.FlinkApplicationVersionStatus{
+				{
 					JobStatus: v1beta1.FlinkJobStatus{
 						JobID: jobID,
 					},
@@ -900,7 +900,7 @@ func TestDeleteWithSavepointAndFinishedJob(t *testing.T) {
 			DeployHash:    "deployhash",
 			SavepointPath: "file:///savepoint",
 			VersionStatuses: []v1beta1.FlinkApplicationVersionStatus{
-				v1beta1.FlinkApplicationVersionStatus{
+				{
 					JobStatus: v1beta1.FlinkJobStatus{
 						JobID: jobID,
 					},
@@ -951,7 +951,7 @@ func TestDeleteWithForceCancel(t *testing.T) {
 		Status: v1beta1.FlinkApplicationStatus{
 			Phase: v1beta1.FlinkApplicationDeleting,
 			VersionStatuses: []v1beta1.FlinkApplicationVersionStatus{
-				v1beta1.FlinkApplicationVersionStatus{
+				{
 					JobStatus: v1beta1.FlinkJobStatus{
 						JobID: jobID,
 					},


### PR DESCRIPTION
Allow users to specify serviceType (essential if you are working with Google Kubernetes Engine)
Allow users to specify serviceAnnotations (essential if you are working with Google Kubernetes Engine)