### PR TITLE
Adapt to Flink v1.11 memory configuration

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -146,6 +146,14 @@
   version = "v0.3.0"
 
 [[projects]]
+  digest = "1:ebffb4b4c8ddcf66bb549464183ea2ddbac6c58a803658f67249f83395d17455"
+  name = "github.com/hashicorp/go-version"
+  packages = ["."]
+  pruneopts = ""
+  revision = "59da58cfd357de719a4d16dac30481391a56c002"
+  version = "v1.2.1"
+
+[[projects]]
   digest = "1:85f8f8d390a03287a563e215ea6bd0610c858042731a8b42062435a0dcbc485f"
   name = "github.com/hashicorp/golang-lru"
   packages = [
@@ -944,6 +952,7 @@
   input-imports = [
     "github.com/benlaurie/objecthash/go/objecthash",
     "github.com/go-resty/resty",
+    "github.com/hashicorp/go-version",
     "github.com/jarcoal/httpmock",
     "github.com/kubernetes-sigs/controller-runtime/pkg/runtime/signals",
     "github.com/lyft/flytestdlib/config",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -42,3 +42,7 @@ required = [
 [[constraint]]
   name = "github.com/lyft/flytestdlib"
   version = "0.2.10"
+
+[[constraint]]
+  name = "github.com/hashicorp/go-version"
+  version = "1.2.1"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -8,6 +8,7 @@ required = [
   "k8s.io/code-generator/cmd/informer-gen",
   "k8s.io/gengo/args",
   "github.com/benlaurie/objecthash/go/objecthash",
+  "github.com/hashicorp/go-version",
 ]
 
 [[constraint]]

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -141,6 +141,10 @@ spec:
                   type: number
                   minimum: 0
                   maximum: 1
+                systemMemoryFraction:
+                  type: number
+                  minimum: 0
+                  maximum: 1
                 nodeSelector:
                   type: object
                   properties:
@@ -281,6 +285,10 @@ spec:
                   type: integer
                   minimum: 1
                 offHeapMemoryFraction:
+                  type: number
+                  minimum: 0
+                  maximum: 1
+                systemMemoryFraction:
                   type: number
                   minimum: 0
                   maximum: 1

--- a/docs/crd.md
+++ b/docs/crd.md
@@ -39,8 +39,7 @@ Below is the list of fields in the custom resource and their description:
       Number of task slots per task manager.
 
     * **systemMemoryFraction** `type:float64`
-      A value between 0 and 1 that represents % of container memory dedicated to system / off heap. The
-      remaining memory is given to the taskmanager.
+      A value between 0 and 1 that represents % of container memory dedicated to the system. The remaining memory is given to the taskmanager.
 
     * **nodeSelector** `type:map[string]string`
       Configuration for the node selectors used for the task manager.
@@ -63,8 +62,7 @@ Below is the list of fields in the custom resource and their description:
       correct environment variables are set for High availability mode.
 
     * **systemMemoryFraction** `type:float64`
-      A value between 0 and 1 that represents % of container memory dedicated to system / off heap. The
-      remaining memory is given to the job manager.
+      A value between 0 and 1 that represents % of container memory dedicated to the system. The remaining memory is given to the job manager.
 
     * **nodeSelector** `type:map[string]string`
       Configuration for the node selectors used for the job manager.

--- a/docs/crd.md
+++ b/docs/crd.md
@@ -38,11 +38,9 @@ Below is the list of fields in the custom resource and their description:
     * **taskSlots** `type:int32 required=true`
       Number of task slots per task manager.
 
-    * **offHeapMemoryFraction** `type:float64`
+    * **systemMemoryFraction** `type:float64`
       A value between 0 and 1 that represents % of container memory dedicated to system / off heap. The
-      remaining memory is given to the taskmanager. Note that Flink may further reserve some of this
-      memory for off-heap uses like network buffers, so you may see the JVM heap size configured to
-      a lower amount.
+      remaining memory is given to the taskmanager.
 
     * **nodeSelector** `type:map[string]string`
       Configuration for the node selectors used for the task manager.
@@ -64,9 +62,9 @@ Below is the list of fields in the custom resource and their description:
       Number of job managers for the flink cluster. If multiple job managers are provided, the user has to ensure that
       correct environment variables are set for High availability mode.
 
-    * **offHeapMemoryFraction** `type:float64`
+    * **systemMemoryFraction** `type:float64`
       A value between 0 and 1 that represents % of container memory dedicated to system / off heap. The
-      remaining memory is allocated for heap.
+      remaining memory is given to the job manager.
 
     * **nodeSelector** `type:map[string]string`
       Configuration for the node selectors used for the job manager.

--- a/integ/test_app.yaml
+++ b/integ/test_app.yaml
@@ -14,7 +14,7 @@ spec:
     state.checkpoints.dir: file:///checkpoints/flink/externalized-checkpoints
     state.savepoints.dir: file:///checkpoints/flink/savepoints
   jobManagerConfig:
-    offHeapMemoryFraction: 0.2
+    systemMemoryFraction: 0.2
     resources:
       requests:
         memory: "200Mi"
@@ -22,7 +22,7 @@ spec:
     replicas: 1
   taskManagerConfig:
     taskSlots: 2
-    offHeapMemoryFraction: 0.5
+    systemMemoryFraction: 0.5
     resources:
       requests:
         memory: "400Mi"
@@ -37,7 +37,7 @@ spec:
       hostPath:
         path: /tmp/checkpoints
         type: Directory
-  flinkVersion: "1.8"
+  flinkVersion: "1.11"
   deploymentMode: Dual
   jarName: "operator-test-app-1.0.0-SNAPSHOT.jar"
   parallelism: 3

--- a/pkg/apis/app/v1alpha1/types.go
+++ b/pkg/apis/app/v1alpha1/types.go
@@ -103,6 +103,7 @@ type JobManagerConfig struct {
 	EnvConfig             EnvironmentConfig           `json:"envConfig"`
 	Replicas              *int32                      `json:"replicas,omitempty"`
 	OffHeapMemoryFraction *float64                    `json:"offHeapMemoryFraction,omitempty"`
+	SystemMemoryFraction  *float64                    `json:"systemMemoryFraction,omitempty"`
 	NodeSelector          map[string]string           `json:"nodeSelector,omitempty"`
 }
 
@@ -111,6 +112,7 @@ type TaskManagerConfig struct {
 	EnvConfig             EnvironmentConfig           `json:"envConfig"`
 	TaskSlots             *int32                      `json:"taskSlots,omitempty"`
 	OffHeapMemoryFraction *float64                    `json:"offHeapMemoryFraction,omitempty"`
+	SystemMemoryFraction  *float64                    `json:"systemMemoryFraction,omitempty"`
 	NodeSelector          map[string]string           `json:"nodeSelector,omitempty"`
 }
 

--- a/pkg/apis/app/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/app/v1alpha1/zz_generated.deepcopy.go
@@ -278,6 +278,11 @@ func (in *JobManagerConfig) DeepCopyInto(out *JobManagerConfig) {
 		*out = new(float64)
 		**out = **in
 	}
+	if in.SystemMemoryFraction != nil {
+		in, out := &in.SystemMemoryFraction, &out.SystemMemoryFraction
+		*out = new(float64)
+		**out = **in
+	}
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
 		*out = make(map[string]string, len(*in))
@@ -330,6 +335,11 @@ func (in *TaskManagerConfig) DeepCopyInto(out *TaskManagerConfig) {
 	}
 	if in.OffHeapMemoryFraction != nil {
 		in, out := &in.OffHeapMemoryFraction, &out.OffHeapMemoryFraction
+		*out = new(float64)
+		**out = **in
+	}
+	if in.SystemMemoryFraction != nil {
+		in, out := &in.SystemMemoryFraction, &out.SystemMemoryFraction
 		*out = new(float64)
 		**out = **in
 	}

--- a/pkg/apis/app/v1beta1/types.go
+++ b/pkg/apis/app/v1beta1/types.go
@@ -107,21 +107,25 @@ func (in *FlinkConfig) DeepCopy() *FlinkConfig {
 }
 
 type JobManagerConfig struct {
-	Resources             *apiv1.ResourceRequirements `json:"resources,omitempty"`
-	EnvConfig             EnvironmentConfig           `json:"envConfig"`
-	Replicas              *int32                      `json:"replicas,omitempty"`
-	OffHeapMemoryFraction *float64                    `json:"offHeapMemoryFraction,omitempty"`
-	NodeSelector          map[string]string           `json:"nodeSelector,omitempty"`
-	Tolerations           []apiv1.Toleration          `json:"tolerations,omitempty"`
+	Resources *apiv1.ResourceRequirements `json:"resources,omitempty"`
+	EnvConfig EnvironmentConfig           `json:"envConfig"`
+	Replicas  *int32                      `json:"replicas,omitempty"`
+	// Deprecated: use SystemMemoryFraction instead
+	OffHeapMemoryFraction *float64           `json:"offHeapMemoryFraction,omitempty"`
+	SystemMemoryFraction  *float64           `json:"systemMemoryFraction,omitempty"`
+	NodeSelector          map[string]string  `json:"nodeSelector,omitempty"`
+	Tolerations           []apiv1.Toleration `json:"tolerations,omitempty"`
 }
 
 type TaskManagerConfig struct {
-	Resources             *apiv1.ResourceRequirements `json:"resources,omitempty"`
-	EnvConfig             EnvironmentConfig           `json:"envConfig"`
-	TaskSlots             *int32                      `json:"taskSlots,omitempty"`
-	OffHeapMemoryFraction *float64                    `json:"offHeapMemoryFraction,omitempty"`
-	NodeSelector          map[string]string           `json:"nodeSelector,omitempty"`
-	Tolerations           []apiv1.Toleration          `json:"tolerations,omitempty"`
+	Resources *apiv1.ResourceRequirements `json:"resources,omitempty"`
+	EnvConfig EnvironmentConfig           `json:"envConfig"`
+	TaskSlots *int32                      `json:"taskSlots,omitempty"`
+	// Deprecated: use SystemMemoryFraction instead
+	OffHeapMemoryFraction *float64           `json:"offHeapMemoryFraction,omitempty"`
+	SystemMemoryFraction  *float64           `json:"systemMemoryFraction,omitempty"`
+	NodeSelector          map[string]string  `json:"nodeSelector,omitempty"`
+	Tolerations           []apiv1.Toleration `json:"tolerations,omitempty"`
 }
 
 type EnvironmentConfig struct {

--- a/pkg/apis/app/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/app/v1beta1/zz_generated.deepcopy.go
@@ -317,6 +317,11 @@ func (in *JobManagerConfig) DeepCopyInto(out *JobManagerConfig) {
 		*out = new(float64)
 		**out = **in
 	}
+	if in.SystemMemoryFraction != nil {
+		in, out := &in.SystemMemoryFraction, &out.SystemMemoryFraction
+		*out = new(float64)
+		**out = **in
+	}
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
 		*out = make(map[string]string, len(*in))
@@ -376,6 +381,11 @@ func (in *TaskManagerConfig) DeepCopyInto(out *TaskManagerConfig) {
 	}
 	if in.OffHeapMemoryFraction != nil {
 		in, out := &in.OffHeapMemoryFraction, &out.OffHeapMemoryFraction
+		*out = new(float64)
+		**out = **in
+	}
+	if in.SystemMemoryFraction != nil {
+		in, out := &in.SystemMemoryFraction, &out.SystemMemoryFraction
 		*out = new(float64)
 		**out = **in
 	}

--- a/pkg/controller/flink/config.go
+++ b/pkg/controller/flink/config.go
@@ -141,7 +141,7 @@ func renderFlinkConfig(app *v1beta1.FlinkApplication) (string, error) {
 	appVersion, err := version.NewVersion(getFlinkVersion(app))
 	v11, err := version.NewVersion("1.11")
 
-	if err != nil || appVersion.LessThan(v11) {
+	if err != nil || appVersion == nil || appVersion.LessThan(v11) {
 		(*config)["jobmanager.heap.size"] = getJobManagerHeapMemory(app)
 		(*config)["taskmanager.heap.size"] = getTaskManagerHeapMemory(app)
 	} else {

--- a/pkg/controller/flink/config.go
+++ b/pkg/controller/flink/config.go
@@ -139,7 +139,7 @@ func renderFlinkConfig(app *v1beta1.FlinkApplication) (string, error) {
 	(*config)["metrics.internal.query-service.port"] = getInternalMetricsQueryPort(app)
 
 	appVersion, err := version.NewVersion(getFlinkVersion(app))
-	v11, err := version.NewVersion("1.11")
+	v11, _ := version.NewVersion("1.11")
 
 	if err != nil || appVersion == nil || appVersion.LessThan(v11) {
 		(*config)["jobmanager.heap.size"] = getJobManagerHeapMemory(app)

--- a/pkg/controller/flink/config.go
+++ b/pkg/controller/flink/config.go
@@ -18,7 +18,8 @@ const (
 	BlobDefaultPort                = 6125
 	UIDefaultPort                  = 8081
 	MetricsQueryDefaultPort        = 50101
-	SystemMemoryDefaultFraction    = 0.5
+	OffHeapMemoryDefaultFraction   = 0.5
+	SystemMemoryDefaultFraction    = 0.2
 	HighAvailabilityKey            = "high-availability"
 	MaxCheckpointRestoreAgeSeconds = 3600
 )
@@ -36,6 +37,9 @@ func getFraction(systemMemoryFraction *float64, offHeapMemoryFraction *float64) 
 	}
 	if isValidFraction(offHeapMemoryFraction) {
 		return *offHeapMemoryFraction
+	}
+	if offHeapMemoryFraction != nil {
+		return OffHeapMemoryDefaultFraction
 	}
 
 	return SystemMemoryDefaultFraction

--- a/pkg/controller/flink/config.go
+++ b/pkg/controller/flink/config.go
@@ -143,7 +143,9 @@ func renderFlinkConfig(app *v1beta1.FlinkApplication) (string, error) {
 	appVersion, err := version.NewVersion(getFlinkVersion(app))
 	v11, _ := version.NewVersion("1.11")
 
+	//nolint // fall back to the old config for backwards-compatibility
 	jobManagerFraction := getFraction(app.Spec.JobManagerConfig.SystemMemoryFraction, app.Spec.JobManagerConfig.OffHeapMemoryFraction)
+	//nolint // fall back to the old config for backwards-compatibility
 	taskManagerFraction := getFraction(app.Spec.TaskManagerConfig.SystemMemoryFraction, app.Spec.TaskManagerConfig.OffHeapMemoryFraction)
 
 	if err != nil || appVersion == nil || appVersion.LessThan(v11) {

--- a/pkg/controller/flink/config_test.go
+++ b/pkg/controller/flink/config_test.go
@@ -303,6 +303,8 @@ func TestMemoryConfigurationForVersionBelow11(t *testing.T) {
 		"1.9",
 		"1.8.0",
 		"1.8",
+		"",
+		"invalid_version",
 	}
 
 	for _, version := range versions {

--- a/pkg/controller/flink/config_test.go
+++ b/pkg/controller/flink/config_test.go
@@ -144,6 +144,7 @@ func TestEnsureNoFractionalHeapMemory(t *testing.T) {
 	}
 	offHeapMemoryFraction := float64(0.37)
 	app.Spec.TaskManagerConfig.Resources = &tmResources
+	//nolint // fall back to the old config for backwards-compatibility
 	app.Spec.TaskManagerConfig.OffHeapMemoryFraction = &offHeapMemoryFraction
 
 	assert.Equal(t, "41287k", getTaskManagerMemory(&app, offHeapMemoryFraction))

--- a/pkg/controller/flink/config_test.go
+++ b/pkg/controller/flink/config_test.go
@@ -285,12 +285,12 @@ func TestMemoryConfigurationForVersionEqualsOrAbove11(t *testing.T) {
 
 		expected := []string{
 			fmt.Sprintf("blob.server.port: %d", BlobDefaultPort),
-			"jobmanager.memory.process.size: 262144k",
+			"jobmanager.memory.process.size: 419430k",
 			fmt.Sprintf("jobmanager.rpc.port: %d", RPCDefaultPort),
 			fmt.Sprintf("jobmanager.web.port: %d", UIDefaultPort),
 			fmt.Sprintf("metrics.internal.query-service.port: %d", MetricsQueryDefaultPort),
 			fmt.Sprintf("query.server.port: %d", QueryDefaultPort),
-			"taskmanager.memory.process.size: 1048576k",
+			"taskmanager.memory.process.size: 1677721k",
 			fmt.Sprintf("taskmanager.numberOfTaskSlots: %d", TaskManagerDefaultSlots),
 		}
 
@@ -316,12 +316,12 @@ func TestMemoryConfigurationForVersionBelow11(t *testing.T) {
 
 		expected := []string{
 			fmt.Sprintf("blob.server.port: %d", BlobDefaultPort),
-			"jobmanager.heap.size: 262144k",
+			"jobmanager.heap.size: 419430k",
 			fmt.Sprintf("jobmanager.rpc.port: %d", RPCDefaultPort),
 			fmt.Sprintf("jobmanager.web.port: %d", UIDefaultPort),
 			fmt.Sprintf("metrics.internal.query-service.port: %d", MetricsQueryDefaultPort),
 			fmt.Sprintf("query.server.port: %d", QueryDefaultPort),
-			"taskmanager.heap.size: 1048576k",
+			"taskmanager.heap.size: 1677721k",
 			fmt.Sprintf("taskmanager.numberOfTaskSlots: %d", TaskManagerDefaultSlots),
 		}
 

--- a/pkg/controller/flink/config_test.go
+++ b/pkg/controller/flink/config_test.go
@@ -31,10 +31,12 @@ func TestRenderFlinkConfigOverrides(t *testing.T) {
 				"env.java.opts.jobmanager":                "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=39000 -XX:+UseG1GC",
 			},
 			TaskManagerConfig: v1beta1.TaskManagerConfig{
-				TaskSlots:             &taskSlots,
+				TaskSlots: &taskSlots,
+				//nolint // fall back to the old config for backwards-compatibility
 				OffHeapMemoryFraction: &offHeapMemoryFrac,
 			},
 			JobManagerConfig: v1beta1.JobManagerConfig{
+				//nolint // fall back to the old config for backwards-compatibility
 				OffHeapMemoryFraction: &offHeapMemoryFrac,
 			},
 			BlobPort: &blobPort,
@@ -161,6 +163,7 @@ func TestGetTaskManagerHeapMemory(t *testing.T) {
 	}
 	offHeapMemoryFraction := float64(0.5)
 	app.Spec.TaskManagerConfig.Resources = &tmResources
+	//nolint // fall back to the old config for backwards-compatibility
 	app.Spec.TaskManagerConfig.OffHeapMemoryFraction = &offHeapMemoryFraction
 
 	assert.Equal(t, "32768k", getTaskManagerMemory(&app, offHeapMemoryFraction))
@@ -180,6 +183,7 @@ func TestGetJobManagerHeapMemory(t *testing.T) {
 	}
 	offHeapMemoryFraction := float64(0.5)
 	app.Spec.JobManagerConfig.Resources = &jmResources
+	//nolint // fall back to the old config for backwards-compatibility
 	app.Spec.JobManagerConfig.OffHeapMemoryFraction = &offHeapMemoryFraction
 
 	assert.Equal(t, "32768k", getJobManagerMemory(&app, offHeapMemoryFraction))

--- a/pkg/controller/flink/flink_test.go
+++ b/pkg/controller/flink/flink_test.go
@@ -31,7 +31,7 @@ import (
 const testImage = "123.xyz.com/xx:11ae1218924428faabd9b64423fa0c332efba6b2"
 
 // Note: if you find yourself changing this to fix a test, that should be treated as a breaking API change
-const testAppHash = "752c76d3"
+const testAppHash = "371961d2"
 const testAppName = "app-name"
 const testNamespace = "ns"
 const testJobID = "j1"

--- a/pkg/controller/flink/job_manager_controller_test.go
+++ b/pkg/controller/flink/job_manager_controller_test.go
@@ -69,11 +69,12 @@ func TestJobManagerCreateSuccess(t *testing.T) {
 		Effect:   "NoSchedule",
 	}}
 
-	hash := "5e7c7283"
 	annotations := map[string]string{
 		"key":                  "annotation",
 		"flink-job-properties": "jarName: " + testJarName + "\nparallelism: 8\nentryClass:" + testEntryClass + "\nprogramArgs:\"" + testProgramArgs + "\"",
 	}
+	app.Annotations = annotations
+	hash := "10a41c95"
 	app.Annotations = common.DuplicateMap(annotations)
 	expectedLabels := map[string]string{
 		"flink-app":             "app-name",
@@ -104,10 +105,10 @@ func TestJobManagerCreateSuccess(t *testing.T) {
 			assert.Equal(t, "flink.k8s.io/v1beta1", deployment.OwnerReferences[0].APIVersion)
 			assert.Equal(t, "FlinkApplication", deployment.OwnerReferences[0].Kind)
 
-			assert.Equal(t, "blob.server.port: 6125\njobmanager.heap.size: 1572864k\n"+
+			assert.Equal(t, "blob.server.port: 6125\njobmanager.heap.size: 2516582k\n"+
 				"jobmanager.rpc.port: 6123\n"+
 				"jobmanager.web.port: 8081\nmetrics.internal.query-service.port: 50101\n"+
-				"query.server.port: 6124\ntaskmanager.heap.size: 524288k\n"+
+				"query.server.port: 6124\ntaskmanager.heap.size: 838860k\n"+
 				"taskmanager.numberOfTaskSlots: 16\n\n"+
 				"jobmanager.rpc.address: app-name-"+hash+"\n",
 				common.GetEnvVar(deployment.Spec.Template.Spec.Containers[0].Env,
@@ -160,7 +161,7 @@ func TestJobManagerHACreateSuccess(t *testing.T) {
 	app.Spec.FlinkConfig = map[string]interface{}{
 		"high-availability": "zookeeper",
 	}
-	hash := "52623ded"
+	hash := "a860c62b"
 	expectedLabels := map[string]string{
 		"flink-app":             "app-name",
 		"flink-app-hash":        hash,
@@ -186,10 +187,10 @@ func TestJobManagerHACreateSuccess(t *testing.T) {
 			assert.Equal(t, "flink.k8s.io/v1beta1", deployment.OwnerReferences[0].APIVersion)
 			assert.Equal(t, "FlinkApplication", deployment.OwnerReferences[0].Kind)
 
-			assert.Equal(t, "blob.server.port: 6125\nhigh-availability: zookeeper\njobmanager.heap.size: 1572864k\n"+
+			assert.Equal(t, "blob.server.port: 6125\nhigh-availability: zookeeper\njobmanager.heap.size: 2516582k\n"+
 				"jobmanager.rpc.port: 6123\n"+
 				"jobmanager.web.port: 8081\nmetrics.internal.query-service.port: 50101\n"+
-				"query.server.port: 6124\ntaskmanager.heap.size: 524288k\n"+
+				"query.server.port: 6124\ntaskmanager.heap.size: 838860k\n"+
 				"taskmanager.numberOfTaskSlots: 16\n\n"+
 				"high-availability.cluster-id: app-name-"+hash+"\n"+
 				"jobmanager.rpc.address: $HOST_IP\n",
@@ -247,7 +248,7 @@ func TestJobManagerSecurityContextAssignment(t *testing.T) {
 		RunAsNonRoot: &runAsNonRoot,
 	}
 
-	hash := "c06b960b"
+	hash := "26ca0a3a"
 
 	ctr := 0
 	mockK8Cluster := testController.k8Cluster.(*k8mock.K8Cluster)
@@ -373,7 +374,7 @@ func TestJobManagerCreateSuccessWithVersion(t *testing.T) {
 		"flink-job-properties":      "jarName: " + testJarName + "\nparallelism: 8\nentryClass:" + testEntryClass + "\nprogramArgs:\"" + testProgramArgs + "\"",
 	}
 	app.Annotations = common.DuplicateMap(annotations)
-	hash := "5cb5943e"
+	hash := "6f67fe75"
 	expectedLabels := map[string]string{
 		"flink-app":                 "app-name",
 		"flink-app-hash":            hash,
@@ -400,10 +401,10 @@ func TestJobManagerCreateSuccessWithVersion(t *testing.T) {
 			assert.Equal(t, "flink.k8s.io/v1beta1", deployment.OwnerReferences[0].APIVersion)
 			assert.Equal(t, "FlinkApplication", deployment.OwnerReferences[0].Kind)
 
-			assert.Equal(t, "blob.server.port: 6125\njobmanager.heap.size: 1572864k\n"+
+			assert.Equal(t, "blob.server.port: 6125\njobmanager.heap.size: 2516582k\n"+
 				"jobmanager.rpc.port: 6123\n"+
 				"jobmanager.web.port: 8081\nmetrics.internal.query-service.port: 50101\n"+
-				"query.server.port: 6124\ntaskmanager.heap.size: 524288k\n"+
+				"query.server.port: 6124\ntaskmanager.heap.size: 838860k\n"+
 				"taskmanager.numberOfTaskSlots: 16\n\n"+
 				"jobmanager.rpc.address: app-name-"+hash+"\n",
 				common.GetEnvVar(deployment.Spec.Template.Spec.Containers[0].Env,

--- a/pkg/controller/flink/task_manager_controller_test.go
+++ b/pkg/controller/flink/task_manager_controller_test.go
@@ -76,7 +76,7 @@ func TestTaskManagerCreateSuccess(t *testing.T) {
 		"flink-job-properties": "jarName: test.jar\nparallelism: 8\nentryClass:com.test.MainClass\nprogramArgs:\"--test\"",
 	}
 
-	hash := "6b5e9b61"
+	hash := "a5ebc547"
 
 	app.Annotations = common.DuplicateMap(annotations)
 	expectedLabels := map[string]string{
@@ -97,10 +97,10 @@ func TestTaskManagerCreateSuccess(t *testing.T) {
 		assert.Equal(t, expectedLabels, deployment.Labels)
 		assert.Equal(t, app.Spec.TaskManagerConfig.Tolerations, deployment.Spec.Template.Spec.Tolerations)
 
-		assert.Equal(t, "blob.server.port: 6125\njobmanager.heap.size: 1572864k\n"+
+		assert.Equal(t, "blob.server.port: 6125\njobmanager.heap.size: 2516582k\n"+
 			"jobmanager.rpc.port: 6123\n"+
 			"jobmanager.web.port: 8081\nmetrics.internal.query-service.port: 50101\n"+
-			"query.server.port: 6124\ntaskmanager.heap.size: 524288k\n"+
+			"query.server.port: 6124\ntaskmanager.heap.size: 838860k\n"+
 			"taskmanager.numberOfTaskSlots: 16\n\n"+
 			"jobmanager.rpc.address: app-name-"+hash+"\n"+
 			"taskmanager.host: $HOST_IP\n",
@@ -125,7 +125,7 @@ func TestTaskManagerHACreateSuccess(t *testing.T) {
 		"flink-job-properties": "jarName: test.jar\nparallelism: 8\nentryClass:com.test.MainClass\nprogramArgs:\"--test\"",
 	}
 
-	hash := "52623ded"
+	hash := "a860c62b"
 	app.Spec.FlinkConfig = map[string]interface{}{
 		"high-availability": "zookeeper",
 	}
@@ -147,10 +147,10 @@ func TestTaskManagerHACreateSuccess(t *testing.T) {
 		assert.Equal(t, app.Namespace, deployment.Spec.Template.Namespace)
 		assert.Equal(t, expectedLabels, deployment.Labels)
 
-		assert.Equal(t, "blob.server.port: 6125\nhigh-availability: zookeeper\njobmanager.heap.size: 1572864k\n"+
+		assert.Equal(t, "blob.server.port: 6125\nhigh-availability: zookeeper\njobmanager.heap.size: 2516582k\n"+
 			"jobmanager.rpc.port: 6123\n"+
 			"jobmanager.web.port: 8081\nmetrics.internal.query-service.port: 50101\n"+
-			"query.server.port: 6124\ntaskmanager.heap.size: 524288k\n"+
+			"query.server.port: 6124\ntaskmanager.heap.size: 838860k\n"+
 			"taskmanager.numberOfTaskSlots: 16\n\n"+
 			"high-availability.cluster-id: app-name-"+hash+"\n"+
 			"taskmanager.host: $HOST_IP\n",
@@ -188,7 +188,7 @@ func TestTaskManagerSecurityContextAssignment(t *testing.T) {
 		RunAsNonRoot: &runAsNonRoot,
 	}
 
-	hash := "c06b960b"
+	hash := "26ca0a3a"
 
 	mockK8Cluster := testController.k8Cluster.(*k8mock.K8Cluster)
 	mockK8Cluster.CreateK8ObjectFunc = func(ctx context.Context, object runtime.Object) error {
@@ -249,7 +249,7 @@ func TestTaskManagerCreateSuccessWithVersion(t *testing.T) {
 		"flink-job-properties":      "jarName: test.jar\nparallelism: 8\nentryClass:com.test.MainClass\nprogramArgs:\"--test\"",
 	}
 
-	hash := "5cb5943e"
+	hash := "6f67fe75"
 
 	app.Annotations = common.DuplicateMap(annotations)
 	expectedLabels := map[string]string{
@@ -270,10 +270,10 @@ func TestTaskManagerCreateSuccessWithVersion(t *testing.T) {
 		assert.Equal(t, app.Namespace, deployment.Spec.Template.Namespace)
 		assert.Equal(t, expectedLabels, deployment.Labels)
 
-		assert.Equal(t, "blob.server.port: 6125\njobmanager.heap.size: 1572864k\n"+
+		assert.Equal(t, "blob.server.port: 6125\njobmanager.heap.size: 2516582k\n"+
 			"jobmanager.rpc.port: 6123\n"+
 			"jobmanager.web.port: 8081\nmetrics.internal.query-service.port: 50101\n"+
-			"query.server.port: 6124\ntaskmanager.heap.size: 524288k\n"+
+			"query.server.port: 6124\ntaskmanager.heap.size: 838860k\n"+
 			"taskmanager.numberOfTaskSlots: 16\n\n"+
 			"jobmanager.rpc.address: app-name-"+hash+"\n"+
 			"taskmanager.host: $HOST_IP\n",

--- a/pkg/controller/flinkapplication/flink_state_machine_test.go
+++ b/pkg/controller/flinkapplication/flink_state_machine_test.go
@@ -1647,7 +1647,7 @@ func TestDeleteWhenCheckSavepointStatusFailing(t *testing.T) {
 
 func TestRunningToDualRunning(t *testing.T) {
 	deployHash := "appHash"
-	updatingHash := "2845d780"
+	updatingHash := "b1b084ee"
 	triggerID := "trigger"
 	savepointPath := "savepointPath"
 	app := v1beta1.FlinkApplication{
@@ -1832,7 +1832,7 @@ func TestRunningToDualRunning(t *testing.T) {
 func TestDualRunningToRunning(t *testing.T) {
 	deployHash := "appHash"
 	updatingHash := "2845d780"
-	teardownHash := "9dc7d91b"
+	teardownHash := "6c87fe8f"
 
 	app := v1beta1.FlinkApplication{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
The memory setup has changed a lot with the 1.10 release for TaskManagers and with the 1.11 release for JobManagers.

The options set by the operator (`jobmanager.heap.size` and `taskmanager.heap.size`) are now deprecated. They can still be used in order to maintain backwards compatibility but they will be interpreted as a different option. Full migration guide can be found [here](https://ci.apache.org/projects/flink/flink-docs-master/ops/memory/mem_migration.html#migration-guide).

With this change, when the version of Flink that we are deploying is lower than 1.11 nothing will change: memory options will be computed as it was before.
When the Flink version is 1.11 or above, we will set `jobmanager.memory.process.size` and `taskmanager.memory.process.size` using the user defined requested memory.

If no Flink version is specified or we set an incorrect version (non semantic versioning model for example), default configuration will be set.

A new dependency has been added: [go-version](https://github.com/hashicorp/go-version). It helps parsing semantic versioning and comparing between versions.