### PR TITLE
Remove old flink-app-hash selector from generic service

### DIFF
--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -679,6 +679,8 @@ func (s *FlinkStateMachine) updateGenericService(ctx context.Context, app *v1bet
 	if service.Spec.Selector[flink.PodDeploymentSelector] != selector {
 		// the service hasn't yet been updated
 		service.Spec.Selector[flink.PodDeploymentSelector] = selector
+		// remove the old app hash selector if it's still present
+		delete(service.Spec.Selector, flink.FlinkAppHash)
 		err = s.k8Cluster.UpdateK8Object(ctx, service)
 		if err != nil {
 			return err


### PR DESCRIPTION
#209 changed how we associate pods with services; previously we used the `flink-app-hash` label, but in order to decouple hashes from deployments this was changed to the random `pod-deployment-selector`.

For versioned services, this change did not cause any issues, as new versioned services are created for each deploy. The generic (non-versioned) service, however is kept for the lifetime of an application and so needs to be "upgraded" to the new way of selecting pods. #209 included support for upgrading existing services by adding the `pod-deployment-selector` label. However, it did not remove the existing `flink-app-hash` label. This broke generic services for applications that had been deployed on a previous version of the operator.

This PR fixes that, by removing the flink-app-hash label during the deploy process.