### PR TITLE
[STRMCMP-1133] Fix for handling nil deployments

### DIFF
--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -671,6 +671,9 @@ func (s *FlinkStateMachine) updateGenericService(ctx context.Context, app *v1bet
 	}
 
 	deployments, err := s.flinkController.GetDeploymentsForHash(ctx, app, newHash)
+	if deployments == nil {
+		return errors.New("Could not find deployments for service " + service.Name)
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Issue**
There was a bug when the operator is trying to deploy an app when the previous deployment didn't work. The fetch for deployments resulted in `nil` with in-turn caused the operator to panic because the lack of handling of the `nil` case.

**Fix**
Added a check for `nil` deployments which now returns an error and fails the deployment.