### PR TITLE
Fix regression in handling of default heap memory config

### DIFF
--- a/docs/crd.md
+++ b/docs/crd.md
@@ -38,8 +38,17 @@ Below is the list of fields in the custom resource and their description:
     * **taskSlots** `type:int32 required=true`
       Number of task slots per task manager.
 
+    * **offHeapMemoryFraction** `type:float64`
+      **For Flink 1.10 and below**
+      A value between 0 and 1 that represents % of container memory dedicated to system / off heap. The
+      remaining memory is given to the taskmanager. Note that Flink may further reserve some of this
+      memory for off-heap uses like network buffers, so you may see the JVM heap size configured to
+      a lower amount. This configures `taskmanager.heap.size`.
+
     * **systemMemoryFraction** `type:float64`
-      A value between 0 and 1 that represents % of container memory dedicated to the system. The remaining memory is given to the taskmanager.
+      **For Flink 1.11 and above**
+      A value between 0 and 1 that represents % of container memory dedicated to the system. The remaining memory is 
+      given to the taskmanager process. This configures `taskmanger.memory.process.size`.
 
     * **nodeSelector** `type:map[string]string`
       Configuration for the node selectors used for the task manager.
@@ -61,8 +70,17 @@ Below is the list of fields in the custom resource and their description:
       Number of job managers for the flink cluster. If multiple job managers are provided, the user has to ensure that
       correct environment variables are set for High availability mode.
 
+    * **offHeapMemoryFraction** `type:float64`
+      **For Flink 1.10 and below**
+      A value between 0 and 1 that represents % of container memory dedicated to system / off heap. The
+      remaining memory is given to the jobmanager. Note that Flink may further reserve some of this
+      memory for off-heap uses like network buffers, so you may see the JVM heap size configured to
+      a lower amount. This configures `jobmanager.heap.size`.
+
     * **systemMemoryFraction** `type:float64`
-      A value between 0 and 1 that represents % of container memory dedicated to the system. The remaining memory is given to the job manager.
+      **For Flink 1.11 and above**
+      A value between 0 and 1 that represents % of container memory dedicated to the system. The remaining memory is 
+      given to the jobmanager process. This configures `jobmanager.memory.process.size`.
 
     * **nodeSelector** `type:map[string]string`
       Configuration for the node selectors used for the job manager.

--- a/pkg/apis/app/v1beta1/types.go
+++ b/pkg/apis/app/v1beta1/types.go
@@ -110,7 +110,6 @@ type JobManagerConfig struct {
 	Resources *apiv1.ResourceRequirements `json:"resources,omitempty"`
 	EnvConfig EnvironmentConfig           `json:"envConfig"`
 	Replicas  *int32                      `json:"replicas,omitempty"`
-	// Deprecated: use SystemMemoryFraction instead
 	OffHeapMemoryFraction *float64           `json:"offHeapMemoryFraction,omitempty"`
 	SystemMemoryFraction  *float64           `json:"systemMemoryFraction,omitempty"`
 	NodeSelector          map[string]string  `json:"nodeSelector,omitempty"`
@@ -121,7 +120,6 @@ type TaskManagerConfig struct {
 	Resources *apiv1.ResourceRequirements `json:"resources,omitempty"`
 	EnvConfig EnvironmentConfig           `json:"envConfig"`
 	TaskSlots *int32                      `json:"taskSlots,omitempty"`
-	// Deprecated: use SystemMemoryFraction instead
 	OffHeapMemoryFraction *float64           `json:"offHeapMemoryFraction,omitempty"`
 	SystemMemoryFraction  *float64           `json:"systemMemoryFraction,omitempty"`
 	NodeSelector          map[string]string  `json:"nodeSelector,omitempty"`

--- a/pkg/apis/app/v1beta1/types.go
+++ b/pkg/apis/app/v1beta1/types.go
@@ -107,23 +107,23 @@ func (in *FlinkConfig) DeepCopy() *FlinkConfig {
 }
 
 type JobManagerConfig struct {
-	Resources *apiv1.ResourceRequirements `json:"resources,omitempty"`
-	EnvConfig EnvironmentConfig           `json:"envConfig"`
-	Replicas  *int32                      `json:"replicas,omitempty"`
-	OffHeapMemoryFraction *float64           `json:"offHeapMemoryFraction,omitempty"`
-	SystemMemoryFraction  *float64           `json:"systemMemoryFraction,omitempty"`
-	NodeSelector          map[string]string  `json:"nodeSelector,omitempty"`
-	Tolerations           []apiv1.Toleration `json:"tolerations,omitempty"`
+	Resources             *apiv1.ResourceRequirements `json:"resources,omitempty"`
+	EnvConfig             EnvironmentConfig           `json:"envConfig"`
+	Replicas              *int32                      `json:"replicas,omitempty"`
+	OffHeapMemoryFraction *float64                    `json:"offHeapMemoryFraction,omitempty"`
+	SystemMemoryFraction  *float64                    `json:"systemMemoryFraction,omitempty"`
+	NodeSelector          map[string]string           `json:"nodeSelector,omitempty"`
+	Tolerations           []apiv1.Toleration          `json:"tolerations,omitempty"`
 }
 
 type TaskManagerConfig struct {
-	Resources *apiv1.ResourceRequirements `json:"resources,omitempty"`
-	EnvConfig EnvironmentConfig           `json:"envConfig"`
-	TaskSlots *int32                      `json:"taskSlots,omitempty"`
-	OffHeapMemoryFraction *float64           `json:"offHeapMemoryFraction,omitempty"`
-	SystemMemoryFraction  *float64           `json:"systemMemoryFraction,omitempty"`
-	NodeSelector          map[string]string  `json:"nodeSelector,omitempty"`
-	Tolerations           []apiv1.Toleration `json:"tolerations,omitempty"`
+	Resources             *apiv1.ResourceRequirements `json:"resources,omitempty"`
+	EnvConfig             EnvironmentConfig           `json:"envConfig"`
+	TaskSlots             *int32                      `json:"taskSlots,omitempty"`
+	OffHeapMemoryFraction *float64                    `json:"offHeapMemoryFraction,omitempty"`
+	SystemMemoryFraction  *float64                    `json:"systemMemoryFraction,omitempty"`
+	NodeSelector          map[string]string           `json:"nodeSelector,omitempty"`
+	Tolerations           []apiv1.Toleration          `json:"tolerations,omitempty"`
 }
 
 type EnvironmentConfig struct {

--- a/pkg/controller/flink/config.go
+++ b/pkg/controller/flink/config.go
@@ -129,7 +129,6 @@ func getFlinkVersion(app *v1beta1.FlinkApplication) string {
 	return app.Spec.FlinkVersion
 }
 
-
 // Renders the flink configuration overrides stored in FlinkApplication.FlinkConfig into a
 // YAML string suitable for interpolating into flink-conf.yaml.
 func renderFlinkConfig(app *v1beta1.FlinkApplication) (string, error) {

--- a/pkg/controller/flink/config_test.go
+++ b/pkg/controller/flink/config_test.go
@@ -205,7 +205,6 @@ func TestGetJobManagerDefaultHeapMemory(t *testing.T) {
 	assert.Equal(t, "32768k", getJobManagerHeapMemory(&app))
 }
 
-
 func TestGetJobManagerProcessMemory(t *testing.T) {
 	app := v1beta1.FlinkApplication{}
 	jmResources := coreV1.ResourceRequirements{

--- a/pkg/controller/flink/config_test.go
+++ b/pkg/controller/flink/config_test.go
@@ -147,7 +147,7 @@ func TestEnsureNoFractionalHeapMemory(t *testing.T) {
 	//nolint // fall back to the old config for backwards-compatibility
 	app.Spec.TaskManagerConfig.OffHeapMemoryFraction = &offHeapMemoryFraction
 
-	assert.Equal(t, "41287k", getTaskManagerMemory(&app))
+	assert.Equal(t, "41287k", getTaskManagerHeapMemory(&app))
 }
 
 func TestGetTaskManagerHeapMemory(t *testing.T) {
@@ -164,10 +164,9 @@ func TestGetTaskManagerHeapMemory(t *testing.T) {
 	}
 	offHeapMemoryFraction := float64(0.5)
 	app.Spec.TaskManagerConfig.Resources = &tmResources
-	//nolint // fall back to the old config for backwards-compatibility
 	app.Spec.TaskManagerConfig.OffHeapMemoryFraction = &offHeapMemoryFraction
 
-	assert.Equal(t, "32768k", getTaskManagerMemory(&app))
+	assert.Equal(t, "32768k", getTaskManagerHeapMemory(&app))
 }
 
 func TestGetJobManagerHeapMemory(t *testing.T) {
@@ -184,11 +183,28 @@ func TestGetJobManagerHeapMemory(t *testing.T) {
 	}
 	offHeapMemoryFraction := float64(0.5)
 	app.Spec.JobManagerConfig.Resources = &jmResources
-	//nolint // fall back to the old config for backwards-compatibility
 	app.Spec.JobManagerConfig.OffHeapMemoryFraction = &offHeapMemoryFraction
 
-	assert.Equal(t, "32768k", getJobManagerMemory(&app))
+	assert.Equal(t, "32768k", getJobManagerHeapMemory(&app))
 }
+
+func TestGetJobManagerDefaultHeapMemory(t *testing.T) {
+	app := v1beta1.FlinkApplication{}
+	jmResources := coreV1.ResourceRequirements{
+		Requests: coreV1.ResourceList{
+			coreV1.ResourceCPU:    resource.MustParse("2"),
+			coreV1.ResourceMemory: resource.MustParse("64Mi"),
+		},
+		Limits: coreV1.ResourceList{
+			coreV1.ResourceCPU:    resource.MustParse("2"),
+			coreV1.ResourceMemory: resource.MustParse("64Mi"),
+		},
+	}
+	app.Spec.JobManagerConfig.Resources = &jmResources
+
+	assert.Equal(t, "32768k", getJobManagerHeapMemory(&app))
+}
+
 
 func TestGetJobManagerProcessMemory(t *testing.T) {
 	app := v1beta1.FlinkApplication{}
@@ -206,7 +222,7 @@ func TestGetJobManagerProcessMemory(t *testing.T) {
 	app.Spec.JobManagerConfig.Resources = &jmResources
 	app.Spec.JobManagerConfig.SystemMemoryFraction = &systemMemoryFraction
 
-	assert.Equal(t, "52428k", getJobManagerMemory(&app))
+	assert.Equal(t, "52428k", getJobManagerProcessMemory(&app))
 }
 
 func TestGetTaskManagerProcessMemory(t *testing.T) {
@@ -225,7 +241,7 @@ func TestGetTaskManagerProcessMemory(t *testing.T) {
 	app.Spec.TaskManagerConfig.Resources = &tmResources
 	app.Spec.TaskManagerConfig.SystemMemoryFraction = &systemMemoryFraction
 
-	assert.Equal(t, "52428k", getTaskManagerMemory(&app))
+	assert.Equal(t, "52428k", getTaskManagerProcessMemory(&app))
 }
 
 func MemoryConfigurationForVersion(t *testing.T, version string) []string {
@@ -321,12 +337,12 @@ func TestMemoryConfigurationForVersionBelow11(t *testing.T) {
 
 		expected := []string{
 			fmt.Sprintf("blob.server.port: %d", BlobDefaultPort),
-			"jobmanager.heap.size: 419430k",
+			"jobmanager.heap.size: 262144k",
 			fmt.Sprintf("jobmanager.rpc.port: %d", RPCDefaultPort),
 			fmt.Sprintf("jobmanager.web.port: %d", UIDefaultPort),
 			fmt.Sprintf("metrics.internal.query-service.port: %d", MetricsQueryDefaultPort),
 			fmt.Sprintf("query.server.port: %d", QueryDefaultPort),
-			"taskmanager.heap.size: 1677721k",
+			"taskmanager.heap.size: 1048576k",
 			fmt.Sprintf("taskmanager.numberOfTaskSlots: %d", TaskManagerDefaultSlots),
 		}
 

--- a/pkg/controller/flink/config_test.go
+++ b/pkg/controller/flink/config_test.go
@@ -147,7 +147,7 @@ func TestEnsureNoFractionalHeapMemory(t *testing.T) {
 	//nolint // fall back to the old config for backwards-compatibility
 	app.Spec.TaskManagerConfig.OffHeapMemoryFraction = &offHeapMemoryFraction
 
-	assert.Equal(t, "41287k", getTaskManagerMemory(&app, offHeapMemoryFraction))
+	assert.Equal(t, "41287k", getTaskManagerMemory(&app))
 }
 
 func TestGetTaskManagerHeapMemory(t *testing.T) {
@@ -167,7 +167,7 @@ func TestGetTaskManagerHeapMemory(t *testing.T) {
 	//nolint // fall back to the old config for backwards-compatibility
 	app.Spec.TaskManagerConfig.OffHeapMemoryFraction = &offHeapMemoryFraction
 
-	assert.Equal(t, "32768k", getTaskManagerMemory(&app, offHeapMemoryFraction))
+	assert.Equal(t, "32768k", getTaskManagerMemory(&app))
 }
 
 func TestGetJobManagerHeapMemory(t *testing.T) {
@@ -187,7 +187,7 @@ func TestGetJobManagerHeapMemory(t *testing.T) {
 	//nolint // fall back to the old config for backwards-compatibility
 	app.Spec.JobManagerConfig.OffHeapMemoryFraction = &offHeapMemoryFraction
 
-	assert.Equal(t, "32768k", getJobManagerMemory(&app, offHeapMemoryFraction))
+	assert.Equal(t, "32768k", getJobManagerMemory(&app))
 }
 
 func TestGetJobManagerProcessMemory(t *testing.T) {
@@ -206,7 +206,7 @@ func TestGetJobManagerProcessMemory(t *testing.T) {
 	app.Spec.JobManagerConfig.Resources = &jmResources
 	app.Spec.JobManagerConfig.SystemMemoryFraction = &systemMemoryFraction
 
-	assert.Equal(t, "52428k", getJobManagerMemory(&app, systemMemoryFraction))
+	assert.Equal(t, "52428k", getJobManagerMemory(&app))
 }
 
 func TestGetTaskManagerProcessMemory(t *testing.T) {
@@ -225,7 +225,7 @@ func TestGetTaskManagerProcessMemory(t *testing.T) {
 	app.Spec.TaskManagerConfig.Resources = &tmResources
 	app.Spec.TaskManagerConfig.SystemMemoryFraction = &systemMemoryFraction
 
-	assert.Equal(t, "52428k", getTaskManagerMemory(&app, systemMemoryFraction))
+	assert.Equal(t, "52428k", getTaskManagerMemory(&app))
 }
 
 func MemoryConfigurationForVersion(t *testing.T, version string) []string {

--- a/pkg/controller/flink/flink_test.go
+++ b/pkg/controller/flink/flink_test.go
@@ -31,7 +31,7 @@ import (
 const testImage = "123.xyz.com/xx:11ae1218924428faabd9b64423fa0c332efba6b2"
 
 // Note: if you find yourself changing this to fix a test, that should be treated as a breaking API change
-const testAppHash = "371961d2"
+const testAppHash = "752c76d3"
 const testAppName = "app-name"
 const testNamespace = "ns"
 const testJobID = "j1"

--- a/pkg/controller/flink/job_manager_controller_test.go
+++ b/pkg/controller/flink/job_manager_controller_test.go
@@ -74,7 +74,7 @@ func TestJobManagerCreateSuccess(t *testing.T) {
 		"flink-job-properties": "jarName: " + testJarName + "\nparallelism: 8\nentryClass:" + testEntryClass + "\nprogramArgs:\"" + testProgramArgs + "\"",
 	}
 	app.Annotations = annotations
-	hash := "10a41c95"
+	hash := "5e7c7283"
 	app.Annotations = common.DuplicateMap(annotations)
 	expectedLabels := map[string]string{
 		"flink-app":             "app-name",
@@ -105,10 +105,10 @@ func TestJobManagerCreateSuccess(t *testing.T) {
 			assert.Equal(t, "flink.k8s.io/v1beta1", deployment.OwnerReferences[0].APIVersion)
 			assert.Equal(t, "FlinkApplication", deployment.OwnerReferences[0].Kind)
 
-			assert.Equal(t, "blob.server.port: 6125\njobmanager.heap.size: 2516582k\n"+
+			assert.Equal(t, "blob.server.port: 6125\njobmanager.heap.size: 1572864k\n"+
 				"jobmanager.rpc.port: 6123\n"+
 				"jobmanager.web.port: 8081\nmetrics.internal.query-service.port: 50101\n"+
-				"query.server.port: 6124\ntaskmanager.heap.size: 838860k\n"+
+				"query.server.port: 6124\ntaskmanager.heap.size: 524288k\n"+
 				"taskmanager.numberOfTaskSlots: 16\n\n"+
 				"jobmanager.rpc.address: app-name-"+hash+"\n",
 				common.GetEnvVar(deployment.Spec.Template.Spec.Containers[0].Env,
@@ -161,7 +161,7 @@ func TestJobManagerHACreateSuccess(t *testing.T) {
 	app.Spec.FlinkConfig = map[string]interface{}{
 		"high-availability": "zookeeper",
 	}
-	hash := "a860c62b"
+	hash := "52623ded"
 	expectedLabels := map[string]string{
 		"flink-app":             "app-name",
 		"flink-app-hash":        hash,
@@ -187,10 +187,10 @@ func TestJobManagerHACreateSuccess(t *testing.T) {
 			assert.Equal(t, "flink.k8s.io/v1beta1", deployment.OwnerReferences[0].APIVersion)
 			assert.Equal(t, "FlinkApplication", deployment.OwnerReferences[0].Kind)
 
-			assert.Equal(t, "blob.server.port: 6125\nhigh-availability: zookeeper\njobmanager.heap.size: 2516582k\n"+
+			assert.Equal(t, "blob.server.port: 6125\nhigh-availability: zookeeper\njobmanager.heap.size: 1572864k\n"+
 				"jobmanager.rpc.port: 6123\n"+
 				"jobmanager.web.port: 8081\nmetrics.internal.query-service.port: 50101\n"+
-				"query.server.port: 6124\ntaskmanager.heap.size: 838860k\n"+
+				"query.server.port: 6124\ntaskmanager.heap.size: 524288k\n"+
 				"taskmanager.numberOfTaskSlots: 16\n\n"+
 				"high-availability.cluster-id: app-name-"+hash+"\n"+
 				"jobmanager.rpc.address: $HOST_IP\n",
@@ -248,7 +248,7 @@ func TestJobManagerSecurityContextAssignment(t *testing.T) {
 		RunAsNonRoot: &runAsNonRoot,
 	}
 
-	hash := "26ca0a3a"
+	hash := "c06b960b"
 
 	ctr := 0
 	mockK8Cluster := testController.k8Cluster.(*k8mock.K8Cluster)
@@ -374,7 +374,7 @@ func TestJobManagerCreateSuccessWithVersion(t *testing.T) {
 		"flink-job-properties":      "jarName: " + testJarName + "\nparallelism: 8\nentryClass:" + testEntryClass + "\nprogramArgs:\"" + testProgramArgs + "\"",
 	}
 	app.Annotations = common.DuplicateMap(annotations)
-	hash := "6f67fe75"
+	hash := "5cb5943e"
 	expectedLabels := map[string]string{
 		"flink-app":                 "app-name",
 		"flink-app-hash":            hash,
@@ -401,10 +401,10 @@ func TestJobManagerCreateSuccessWithVersion(t *testing.T) {
 			assert.Equal(t, "flink.k8s.io/v1beta1", deployment.OwnerReferences[0].APIVersion)
 			assert.Equal(t, "FlinkApplication", deployment.OwnerReferences[0].Kind)
 
-			assert.Equal(t, "blob.server.port: 6125\njobmanager.heap.size: 2516582k\n"+
+			assert.Equal(t, "blob.server.port: 6125\njobmanager.heap.size: 1572864k\n"+
 				"jobmanager.rpc.port: 6123\n"+
 				"jobmanager.web.port: 8081\nmetrics.internal.query-service.port: 50101\n"+
-				"query.server.port: 6124\ntaskmanager.heap.size: 838860k\n"+
+				"query.server.port: 6124\ntaskmanager.heap.size: 524288k\n"+
 				"taskmanager.numberOfTaskSlots: 16\n\n"+
 				"jobmanager.rpc.address: app-name-"+hash+"\n",
 				common.GetEnvVar(deployment.Spec.Template.Spec.Containers[0].Env,

--- a/pkg/controller/flink/task_manager_controller_test.go
+++ b/pkg/controller/flink/task_manager_controller_test.go
@@ -76,7 +76,7 @@ func TestTaskManagerCreateSuccess(t *testing.T) {
 		"flink-job-properties": "jarName: test.jar\nparallelism: 8\nentryClass:com.test.MainClass\nprogramArgs:\"--test\"",
 	}
 
-	hash := "a5ebc547"
+	hash := "6b5e9b61"
 
 	app.Annotations = common.DuplicateMap(annotations)
 	expectedLabels := map[string]string{
@@ -97,10 +97,10 @@ func TestTaskManagerCreateSuccess(t *testing.T) {
 		assert.Equal(t, expectedLabels, deployment.Labels)
 		assert.Equal(t, app.Spec.TaskManagerConfig.Tolerations, deployment.Spec.Template.Spec.Tolerations)
 
-		assert.Equal(t, "blob.server.port: 6125\njobmanager.heap.size: 2516582k\n"+
+		assert.Equal(t, "blob.server.port: 6125\njobmanager.heap.size: 1572864k\n"+
 			"jobmanager.rpc.port: 6123\n"+
 			"jobmanager.web.port: 8081\nmetrics.internal.query-service.port: 50101\n"+
-			"query.server.port: 6124\ntaskmanager.heap.size: 838860k\n"+
+			"query.server.port: 6124\ntaskmanager.heap.size: 524288k\n"+
 			"taskmanager.numberOfTaskSlots: 16\n\n"+
 			"jobmanager.rpc.address: app-name-"+hash+"\n"+
 			"taskmanager.host: $HOST_IP\n",
@@ -125,7 +125,7 @@ func TestTaskManagerHACreateSuccess(t *testing.T) {
 		"flink-job-properties": "jarName: test.jar\nparallelism: 8\nentryClass:com.test.MainClass\nprogramArgs:\"--test\"",
 	}
 
-	hash := "a860c62b"
+	hash := "52623ded"
 	app.Spec.FlinkConfig = map[string]interface{}{
 		"high-availability": "zookeeper",
 	}
@@ -147,10 +147,10 @@ func TestTaskManagerHACreateSuccess(t *testing.T) {
 		assert.Equal(t, app.Namespace, deployment.Spec.Template.Namespace)
 		assert.Equal(t, expectedLabels, deployment.Labels)
 
-		assert.Equal(t, "blob.server.port: 6125\nhigh-availability: zookeeper\njobmanager.heap.size: 2516582k\n"+
+		assert.Equal(t, "blob.server.port: 6125\nhigh-availability: zookeeper\njobmanager.heap.size: 1572864k\n"+
 			"jobmanager.rpc.port: 6123\n"+
 			"jobmanager.web.port: 8081\nmetrics.internal.query-service.port: 50101\n"+
-			"query.server.port: 6124\ntaskmanager.heap.size: 838860k\n"+
+			"query.server.port: 6124\ntaskmanager.heap.size: 524288k\n"+
 			"taskmanager.numberOfTaskSlots: 16\n\n"+
 			"high-availability.cluster-id: app-name-"+hash+"\n"+
 			"taskmanager.host: $HOST_IP\n",
@@ -188,7 +188,7 @@ func TestTaskManagerSecurityContextAssignment(t *testing.T) {
 		RunAsNonRoot: &runAsNonRoot,
 	}
 
-	hash := "26ca0a3a"
+	hash := "c06b960b"
 
 	mockK8Cluster := testController.k8Cluster.(*k8mock.K8Cluster)
 	mockK8Cluster.CreateK8ObjectFunc = func(ctx context.Context, object runtime.Object) error {
@@ -249,7 +249,7 @@ func TestTaskManagerCreateSuccessWithVersion(t *testing.T) {
 		"flink-job-properties":      "jarName: test.jar\nparallelism: 8\nentryClass:com.test.MainClass\nprogramArgs:\"--test\"",
 	}
 
-	hash := "6f67fe75"
+	hash := "5cb5943e"
 
 	app.Annotations = common.DuplicateMap(annotations)
 	expectedLabels := map[string]string{
@@ -270,10 +270,10 @@ func TestTaskManagerCreateSuccessWithVersion(t *testing.T) {
 		assert.Equal(t, app.Namespace, deployment.Spec.Template.Namespace)
 		assert.Equal(t, expectedLabels, deployment.Labels)
 
-		assert.Equal(t, "blob.server.port: 6125\njobmanager.heap.size: 2516582k\n"+
+		assert.Equal(t, "blob.server.port: 6125\njobmanager.heap.size: 1572864k\n"+
 			"jobmanager.rpc.port: 6123\n"+
 			"jobmanager.web.port: 8081\nmetrics.internal.query-service.port: 50101\n"+
-			"query.server.port: 6124\ntaskmanager.heap.size: 838860k\n"+
+			"query.server.port: 6124\ntaskmanager.heap.size: 524288k\n"+
 			"taskmanager.numberOfTaskSlots: 16\n\n"+
 			"jobmanager.rpc.address: app-name-"+hash+"\n"+
 			"taskmanager.host: $HOST_IP\n",

--- a/pkg/controller/flinkapplication/flink_state_machine_test.go
+++ b/pkg/controller/flinkapplication/flink_state_machine_test.go
@@ -1740,7 +1740,7 @@ func TestDeleteWhenCheckSavepointStatusFailing(t *testing.T) {
 
 func TestRunningToDualRunning(t *testing.T) {
 	deployHash := "appHash"
-	updatingHash := "b1b084ee"
+	updatingHash := "2845d780"
 	triggerID := "trigger"
 	savepointPath := "savepointPath"
 	app := v1beta1.FlinkApplication{
@@ -1925,7 +1925,7 @@ func TestRunningToDualRunning(t *testing.T) {
 func TestDualRunningToRunning(t *testing.T) {
 	deployHash := "appHash"
 	updatingHash := "2845d780"
-	teardownHash := "6c87fe8f"
+	teardownHash := "9dc7d91b"
 
 	app := v1beta1.FlinkApplication{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
This fixes a regression introduced in #207 which caused us to use the wrong default for heap memory configs in Flink <1.11.

It also simplifies the memory configuration situation a bit. Now, for Flink <1.11 you may only configure memory with the existing `offHeapMemoryFraction` (which translates into `jobmanager.heap.size`/`taskmanager.heap.size`) and for version >= 1.11 you may only use the new `systemMemoryFraction` (which translates to `jobmanager.memory.process.size`/`taskmanager.memory.process.size`). Using an incompatible configuration for the specified `flinkVersion` will produce an error.