### PR TITLE
Updates CRD docs to accurately reflect the behavior of 'savepointpath'.

### DIFF
--- a/docs/crd.md
+++ b/docs/crd.md
@@ -103,6 +103,8 @@ Below is the list of fields in the custom resource and their description:
 
   * **savepointPath** `type:string`
     If specified, the application state will be restored from this savepoint.
+    
+    **This will only have an effect on the first deploy of a cluster. Specifying a savepoint path as an update to an already running cluster is treated as a noop.**
 
   * **savepointDisabled** `type:boolean`
     If specified, during an update, the current application (if existing) is cancelled without taking a savepoint.


### PR DESCRIPTION
Spawned from a question in the community slack channel for this project: [Link to slack conversation](https://flinkk8soperator.slack.com/archives/CMKK848EQ/p1603400167017100).

Specifying `savepointpath` as an update to an already running cluster is treated as a noop, this wasn't clear from the documentation and took us some time to figure this one out. Would be nice if the documentation clearly stated the behavior of this field and how it's expected to behave. 

