### PR TITLE
Support ingress annotations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,6 @@ RUN make linux_compile
 ENV PATH="/artifacts:${PATH}"
 
 # This will eventually move to centurylink/ca-certs:latest for minimum possible image size
-FROM alpine:3.10
+FROM alpine:3.13
 COPY --from=builder /artifacts /bin
 CMD ["flinkoperator"]

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -40,6 +40,12 @@ spec:
                 properties:
                   name:
                     type: string
+            ingressAnnotations:
+              description: May be used to configure the ingress objects
+              type: object
+            ingressTLSSecretName:
+              description: May be used to configure the ingress TLS
+              type: string
             serviceAccountName:
               type: string
             securityContext:

--- a/docs/crd.md
+++ b/docs/crd.md
@@ -166,3 +166,10 @@ Below is the list of fields in the custom resource and their description:
   * **tearDownVersionHash** `type:string`
     Used **only** with the BlueGreen deployment mode. This is set typically once a FlinkApplication successfully transitions to the `DualRunning` phase.
     Once set, the application version corresponding to the hash is torn down. On successful teardown, the FlinkApplication transitions to a `Running` phase.
+
+  * **ingressAnnotations** `type:map[string]string`
+    Optional: Can be set or modified to set ingress Annotion like `kubernetes.io/ingress.class=nginx` or `kubernetes.io/tls-acme=true` to support certmanager/letsencrypt
+
+  * **ingressTLSSecretName** `type:string`
+   Optional: can be set to add a TLS secretname of the the https ingress
+

--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -73,7 +73,7 @@ The above command will create the flink application custom resource in kubernete
 Command below should show deployments created for the application
 ```bash
 $ kubectl get deployments -n flink-operator
-```
+```8
 
 Check the phase and other status attributes in the custom resource
 ```bash

--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -73,7 +73,7 @@ The above command will create the flink application custom resource in kubernete
 Command below should show deployments created for the application
 ```bash
 $ kubectl get deployments -n flink-operator
-```8
+```
 
 Check the phase and other status attributes in the custom resource
 ```bash

--- a/examples/wordcount/flink-operator-custom-resource.yaml
+++ b/examples/wordcount/flink-operator-custom-resource.yaml
@@ -33,3 +33,11 @@ spec:
   jarName: "wordcount-operator-example-1.0.0-SNAPSHOT.jar"
   parallelism: 3
   entryClass: "org.apache.flink.WordCount"
+  # Any ingress annotations can be set there
+  # ingressAnnotations:
+  #   kubernetes.io/ingress.class: nginx
+  #   kubernetes.io/tls-acme: "true" # support cert-manager / letsencrypt
+  #   nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+
+  # Declare the secret that stores the TLS key and cert
+  # ingressTLSSecretName: "wordcount-operator-example-tls"

--- a/pkg/apis/app/v1beta1/types.go
+++ b/pkg/apis/app/v1beta1/types.go
@@ -28,19 +28,21 @@ type FlinkApplication struct {
 }
 
 type FlinkApplicationSpec struct {
-	Image              string                       `json:"image,omitempty" protobuf:"bytes,2,opt,name=image"`
-	ImagePullPolicy    apiv1.PullPolicy             `json:"imagePullPolicy,omitempty" protobuf:"bytes,14,opt,name=imagePullPolicy,casttype=PullPolicy"`
-	ImagePullSecrets   []apiv1.LocalObjectReference `json:"imagePullSecrets,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,15,rep,name=imagePullSecrets"`
-	ServiceAccountName string                       `json:"serviceAccountName,omitempty"`
-	SecurityContext    *apiv1.PodSecurityContext    `json:"securityContext,omitempty"`
-	FlinkConfig        FlinkConfig                  `json:"flinkConfig"`
-	FlinkVersion       string                       `json:"flinkVersion"`
-	TaskManagerConfig  TaskManagerConfig            `json:"taskManagerConfig,omitempty"`
-	JobManagerConfig   JobManagerConfig             `json:"jobManagerConfig,omitempty"`
-	JarName            string                       `json:"jarName"`
-	Parallelism        int32                        `json:"parallelism"`
-	EntryClass         string                       `json:"entryClass,omitempty"`
-	ProgramArgs        string                       `json:"programArgs,omitempty"`
+	Image                string                       `json:"image,omitempty" protobuf:"bytes,2,opt,name=image"`
+	ImagePullPolicy      apiv1.PullPolicy             `json:"imagePullPolicy,omitempty" protobuf:"bytes,14,opt,name=imagePullPolicy,casttype=PullPolicy"`
+	ImagePullSecrets     []apiv1.LocalObjectReference `json:"imagePullSecrets,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,15,rep,name=imagePullSecrets"`
+	SecurityContext      *apiv1.PodSecurityContext    `json:"securityContext,omitempty"`
+	IngressAnnotations   map[string]string            `json:"ingressAnnotations,omitempty"`
+	IngressTLSSecretName string                       `json:"ingressTLSSecretName,omitempty"`
+	FlinkConfig          FlinkConfig                  `json:"flinkConfig"`
+	ServiceAccountName   string                       `json:"serviceAccountName,omitempty"`
+	FlinkVersion         string                       `json:"flinkVersion"`
+	TaskManagerConfig    TaskManagerConfig            `json:"taskManagerConfig,omitempty"`
+	JobManagerConfig     JobManagerConfig             `json:"jobManagerConfig,omitempty"`
+	JarName              string                       `json:"jarName"`
+	Parallelism          int32                        `json:"parallelism"`
+	EntryClass           string                       `json:"entryClass,omitempty"`
+	ProgramArgs          string                       `json:"programArgs,omitempty"`
 	// Deprecated: use SavepointPath instead
 	SavepointInfo                  SavepointInfo       `json:"savepointInfo,omitempty"`
 	SavepointPath                  string              `json:"savepointPath,omitempty"`

--- a/pkg/apis/app/v1beta1/types.go
+++ b/pkg/apis/app/v1beta1/types.go
@@ -28,21 +28,19 @@ type FlinkApplication struct {
 }
 
 type FlinkApplicationSpec struct {
-	Image                string                       `json:"image,omitempty" protobuf:"bytes,2,opt,name=image"`
-	ImagePullPolicy      apiv1.PullPolicy             `json:"imagePullPolicy,omitempty" protobuf:"bytes,14,opt,name=imagePullPolicy,casttype=PullPolicy"`
-	ImagePullSecrets     []apiv1.LocalObjectReference `json:"imagePullSecrets,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,15,rep,name=imagePullSecrets"`
-	SecurityContext      *apiv1.PodSecurityContext    `json:"securityContext,omitempty"`
-	IngressAnnotations   map[string]string            `json:"ingressAnnotations,omitempty"`
-	IngressTLSSecretName string                       `json:"ingressTLSSecretName,omitempty"`
-	FlinkConfig          FlinkConfig                  `json:"flinkConfig"`
-	ServiceAccountName   string                       `json:"serviceAccountName,omitempty"`
-	FlinkVersion         string                       `json:"flinkVersion"`
-	TaskManagerConfig    TaskManagerConfig            `json:"taskManagerConfig,omitempty"`
-	JobManagerConfig     JobManagerConfig             `json:"jobManagerConfig,omitempty"`
-	JarName              string                       `json:"jarName"`
-	Parallelism          int32                        `json:"parallelism"`
-	EntryClass           string                       `json:"entryClass,omitempty"`
-	ProgramArgs          string                       `json:"programArgs,omitempty"`
+	Image              string                       `json:"image,omitempty" protobuf:"bytes,2,opt,name=image"`
+	ImagePullPolicy    apiv1.PullPolicy             `json:"imagePullPolicy,omitempty" protobuf:"bytes,14,opt,name=imagePullPolicy,casttype=PullPolicy"`
+	ImagePullSecrets   []apiv1.LocalObjectReference `json:"imagePullSecrets,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,15,rep,name=imagePullSecrets"`
+	ServiceAccountName string                       `json:"serviceAccountName,omitempty"`
+	SecurityContext    *apiv1.PodSecurityContext    `json:"securityContext,omitempty"`
+	FlinkConfig        FlinkConfig                  `json:"flinkConfig"`
+	FlinkVersion       string                       `json:"flinkVersion"`
+	TaskManagerConfig  TaskManagerConfig            `json:"taskManagerConfig,omitempty"`
+	JobManagerConfig   JobManagerConfig             `json:"jobManagerConfig,omitempty"`
+	JarName            string                       `json:"jarName"`
+	Parallelism        int32                        `json:"parallelism"`
+	EntryClass         string                       `json:"entryClass,omitempty"`
+	ProgramArgs        string                       `json:"programArgs,omitempty"`
 	// Deprecated: use SavepointPath instead
 	SavepointInfo                  SavepointInfo       `json:"savepointInfo,omitempty"`
 	SavepointPath                  string              `json:"savepointPath,omitempty"`
@@ -62,6 +60,8 @@ type FlinkApplicationSpec struct {
 	ForceRollback                  bool                `json:"forceRollback"`
 	MaxCheckpointRestoreAgeSeconds *int32              `json:"maxCheckpointRestoreAgeSeconds,omitempty"`
 	TearDownVersionHash            string              `json:"tearDownVersionHash,omitempty"`
+	IngressAnnotations             map[string]string   `json:"ingressAnnotations,omitempty"`
+	IngressTLSSecretName           string              `json:"ingressTLSSecretName,omitempty"`
 }
 
 type FlinkConfig map[string]interface{}

--- a/pkg/apis/app/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/app/v1beta1/zz_generated.deepcopy.go
@@ -128,6 +128,13 @@ func (in *FlinkApplicationSpec) DeepCopyInto(out *FlinkApplicationSpec) {
 		*out = make([]v1.LocalObjectReference, len(*in))
 		copy(*out, *in)
 	}
+	if in.IngressAnnotations != nil {
+		in, out := &in.IngressAnnotations, &out.IngressAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.SecurityContext != nil {
 		in, out := &in.SecurityContext, &out.SecurityContext
 		*out = new(v1.PodSecurityContext)

--- a/pkg/controller/flink/ingress.go
+++ b/pkg/controller/flink/ingress.go
@@ -30,9 +30,10 @@ func FetchJobManagerIngressCreateObj(app *flinkapp.FlinkApplication) *v1beta1.In
 	podLabels = common.CopyMap(podLabels, k8.GetAppLabel(app.Name))
 
 	ingressMeta := v1.ObjectMeta{
-		Name:      getJobManagerServiceName(app),
-		Labels:    podLabels,
-		Namespace: app.Namespace,
+		Name:        getJobManagerServiceName(app),
+		Labels:      podLabels,
+		Annotations: app.Spec.IngressAnnotations,
+		Namespace:   app.Namespace,
 		OwnerReferences: []v1.OwnerReference{
 			*v1.NewControllerRef(app, app.GroupVersionKind()),
 		},
@@ -57,6 +58,14 @@ func FetchJobManagerIngressCreateObj(app *flinkapp.FlinkApplication) *v1beta1.In
 				},
 			},
 		}},
+	}
+	if app.Spec.IngressTLSSecretName != "" {
+		ingressSpec.TLS = []v1beta1.IngressTLS{
+			{
+				Hosts:      []string{GetFlinkUIIngressURL(app.Name)},
+				SecretName: app.Spec.IngressTLSSecretName,
+			},
+		}
 	}
 	return &v1beta1.Ingress{
 		ObjectMeta: ingressMeta,


### PR DESCRIPTION
# TL;DR
Based on [PR-188](https://github.com/lyft/flinkk8soperator/pull/188/files)

Supporting ingress annotations and tls Secrets. That allows the usage: 
* different ingress-controllers
* HTTPS with certmanager & letsencrypt
* Authentication on the ingress level

# Running Tests: 

## Apply CRD
```
kubectl apply -f https://raw.githubusercontent.com/iunera/flinkk8soperator/master/deploy/crd.yaml
```

## Dockerimage

Replace `image:` in `deploy/flinkk8soperator.yaml`
```
image: iunera/flinkk8soperator:0.5.1
```

## Ingress
Set some ingressAnnotations in the worcount example `examples/wordcount/flink-operator-custom-resource.yaml`

```
  ingressAnnotations:
    kubernetes.io/ingress.class: nginx
    kubernetes.io/tls-acme: "true"
    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"

  ingressTLSSecretName: "wordcount-operator-example-tls"

```