### PR TITLE
COMPUTE-4871 use rbac.authorization.k8s.io/v1

### DIFF
--- a/deploy/role-binding.yaml
+++ b/deploy/role-binding.yaml
@@ -1,6 +1,6 @@
 # Create a binding from Role -> ServiceAccount
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flinkoperator
 roleRef:


### PR DESCRIPTION
rbac.authorization.k8s.io/v1beta1 is deprecated and will be removed in newer versions of k8s