### PR TITLE
Add x-kubernetes-preserve-unknown-fields to nodeSelector config.

### DIFF
--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -150,6 +150,7 @@ spec:
                   properties:
                     additionalProperties:
                       type: string
+                  x-kubernetes-preserve-unknown-fields: true
                 tolerations:
                   type: array
                   items:
@@ -567,6 +568,7 @@ spec:
                   properties:
                     additionalProperties:
                       type: string
+                  x-kubernetes-preserve-unknown-fields: true
                 tolerations:
                   type: array
                   items:


### PR DESCRIPTION
Fixes #250 

Resolves CRD validation errors in Kubernetes 1.20+ for `nodeSelector` values.