### PR TITLE
Revert "Support kubernetes 1.22 (#258)"

### DIFF
--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: flinkapplications.flink.k8s.io
@@ -12,6 +12,7 @@ spec:
     shortNames:
       - flinkapp
   scope: Namespaced
+  version: v1beta1
   versions:
     - name: v1beta1
       served: true

--- a/deploy/role-binding.yaml
+++ b/deploy/role-binding.yaml
@@ -1,6 +1,6 @@
 # Create a binding from Role -> ServiceAccount
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: flinkoperator
 roleRef:


### PR DESCRIPTION
This reverts commit 773b378f5f8cfa9758e3794b62c8e5fa00020606.

## overview
Removing this as v1 CRD's breaks integration tests which are using an old k8s client. Will save this for when we do the 1.22 upgrade in the near future