### PR TITLE
fix a potential bug

### DIFF
--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -790,6 +790,7 @@ func monitorAllVerticesState(job *client.FlinkJobOverview) (bool, bool, int) {
 		if v.Status == client.Failed {
 			failedVertexIndex = index
 			hasFailure = true
+			allVerticesRunning = false
 			break
 		}
 		allVerticesRunning = allVerticesRunning && (v.StartTime > 0) && v.Status == client.Running


### PR DESCRIPTION
Fix a potential bug. If any vertex is failed, also need to set `allVerticesRunning` parameter to false explicitly. 

Currently this will not cause any issue because caller ignores `allVerticesRunning` if `hasFailure` is true. 

But future caller may make wrong assumption. 