### PR TITLE
fix High availability config to be kubernetes.cluster-id

### DIFF
--- a/pkg/controller/flink/container_utils.go
+++ b/pkg/controller/flink/container_utils.go
@@ -202,7 +202,7 @@ func InjectOperatorCustomizedConfig(deployment *appsv1.Deployment, app *v1beta1.
 		for _, env := range container.Env {
 			if env.Name == OperatorFlinkConfig {
 				if isHAEnabled(app.Spec.FlinkConfig) {
-					env.Value = fmt.Sprintf("%s\nhigh-availability.cluster-id: %s-%s\n", env.Value, app.Name, hash)
+					env.Value = fmt.Sprintf("%s\nkubernetes.cluster-id: %s-%s\n", env.Value, app.Name, hash)
 					if deploymentType == FlinkDeploymentTypeJobmanager {
 						env.Value = fmt.Sprintf("%sjobmanager.rpc.address: $HOST_IP\n", env.Value)
 					}

--- a/pkg/controller/flink/job_manager_controller_test.go
+++ b/pkg/controller/flink/job_manager_controller_test.go
@@ -192,7 +192,7 @@ func TestJobManagerHACreateSuccess(t *testing.T) {
 				"jobmanager.web.port: 8081\nmetrics.internal.query-service.port: 50101\n"+
 				"query.server.port: 6124\ntaskmanager.heap.size: 524288k\n"+
 				"taskmanager.numberOfTaskSlots: 16\n\n"+
-				"high-availability.cluster-id: app-name-"+hash+"\n"+
+				"kubernetes.cluster-id: app-name-"+hash+"\n"+
 				"jobmanager.rpc.address: $HOST_IP\n",
 				common.GetEnvVar(deployment.Spec.Template.Spec.Containers[0].Env,
 					"FLINK_PROPERTIES").Value)

--- a/pkg/controller/flink/task_manager_controller_test.go
+++ b/pkg/controller/flink/task_manager_controller_test.go
@@ -152,7 +152,7 @@ func TestTaskManagerHACreateSuccess(t *testing.T) {
 			"jobmanager.web.port: 8081\nmetrics.internal.query-service.port: 50101\n"+
 			"query.server.port: 6124\ntaskmanager.heap.size: 524288k\n"+
 			"taskmanager.numberOfTaskSlots: 16\n\n"+
-			"high-availability.cluster-id: app-name-"+hash+"\n"+
+			"kubernetes.cluster-id: app-name-"+hash+"\n"+
 			"taskmanager.host: $HOST_IP\n",
 			common.GetEnvVar(deployment.Spec.Template.Spec.Containers[0].Env,
 				"FLINK_PROPERTIES").Value)


### PR DESCRIPTION
The flink High availability should be using `kuberentes.cluster-id` instead of `high-availability.cluster-id` 

Here's the settings: 
https://nightlies.apache.org/flink/flink-docs-release-1.16/docs/deployment/ha/kubernetes_ha/

It seems like in 1.13 is already the same config:
https://nightlies.apache.org/flink/flink-docs-release-1.13/docs/deployment/ha/kubernetes_ha/
