### PR TITLE
[STRMCMP-1659] k8s 1.24 upgrade networking fix

### DIFF
--- a/pkg/controller/flink/ingress.go
+++ b/pkg/controller/flink/ingress.go
@@ -47,13 +47,15 @@ func FetchJobManagerIngressCreateObj(app *flinkapp.FlinkApplication) *networkV1.
 		},
 	}
 
+	pathType := networkV1.PathTypeImplementationSpecific
 	ingressSpec := networkV1.IngressSpec{
 		Rules: []networkV1.IngressRule{{
 			Host: GetFlinkUIIngressURL(getIngressName(app)),
 			IngressRuleValue: networkV1.IngressRuleValue{
 				HTTP: &networkV1.HTTPIngressRuleValue{
 					Paths: []networkV1.HTTPIngressPath{{
-						Backend: backend,
+						Backend:  backend,
+						PathType: &pathType,
 					}},
 				},
 			},

--- a/pkg/controller/flink/ingress.go
+++ b/pkg/controller/flink/ingress.go
@@ -8,9 +8,8 @@ import (
 	"github.com/lyft/flinkk8soperator/pkg/controller/common"
 	"github.com/lyft/flinkk8soperator/pkg/controller/config"
 	"github.com/lyft/flinkk8soperator/pkg/controller/k8"
-	"k8s.io/api/networking/v1beta1"
+	networkV1 "k8s.io/api/networking/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 const AppIngressName = "%s-%s"
@@ -25,7 +24,7 @@ func GetFlinkUIIngressURL(jobName string) string {
 	return ReplaceJobURL(config.GetConfig().FlinkIngressURLFormat, jobName)
 }
 
-func FetchJobManagerIngressCreateObj(app *flinkapp.FlinkApplication) *v1beta1.Ingress {
+func FetchJobManagerIngressCreateObj(app *flinkapp.FlinkApplication) *networkV1.Ingress {
 	podLabels := common.DuplicateMap(app.Labels)
 	podLabels = common.CopyMap(podLabels, k8.GetAppLabel(app.Name))
 
@@ -38,30 +37,32 @@ func FetchJobManagerIngressCreateObj(app *flinkapp.FlinkApplication) *v1beta1.In
 		},
 	}
 
-	backend := v1beta1.IngressBackend{
-		ServiceName: getJobManagerServiceName(app),
-		ServicePort: intstr.IntOrString{
-			Type:   intstr.Int,
-			IntVal: getUIPort(app),
+	backend := networkV1.IngressBackend{
+		Service: &networkV1.IngressServiceBackend{
+			Name: getJobManagerServiceName(app),
+			Port: networkV1.ServiceBackendPort{
+				Name:   getJobManagerServiceName(app),
+				Number: getUIPort(app),
+			},
 		},
 	}
 
-	ingressSpec := v1beta1.IngressSpec{
-		Rules: []v1beta1.IngressRule{{
+	ingressSpec := networkV1.IngressSpec{
+		Rules: []networkV1.IngressRule{{
 			Host: GetFlinkUIIngressURL(getIngressName(app)),
-			IngressRuleValue: v1beta1.IngressRuleValue{
-				HTTP: &v1beta1.HTTPIngressRuleValue{
-					Paths: []v1beta1.HTTPIngressPath{{
+			IngressRuleValue: networkV1.IngressRuleValue{
+				HTTP: &networkV1.HTTPIngressRuleValue{
+					Paths: []networkV1.HTTPIngressPath{{
 						Backend: backend,
 					}},
 				},
 			},
 		}},
 	}
-	return &v1beta1.Ingress{
+	return &networkV1.Ingress{
 		ObjectMeta: ingressMeta,
 		TypeMeta: v1.TypeMeta{
-			APIVersion: v1beta1.SchemeGroupVersion.String(),
+			APIVersion: networkV1.SchemeGroupVersion.String(),
 			Kind:       k8.Ingress,
 		},
 		Spec: ingressSpec,

--- a/pkg/controller/flink/ingress.go
+++ b/pkg/controller/flink/ingress.go
@@ -41,7 +41,6 @@ func FetchJobManagerIngressCreateObj(app *flinkapp.FlinkApplication) *networkV1.
 		Service: &networkV1.IngressServiceBackend{
 			Name: getJobManagerServiceName(app),
 			Port: networkV1.ServiceBackendPort{
-				Name:   getJobManagerServiceName(app),
 				Number: getUIPort(app),
 			},
 		},

--- a/pkg/controller/flink/job_manager_controller_test.go
+++ b/pkg/controller/flink/job_manager_controller_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/apps/v1"
 	coreV1 "k8s.io/api/core/v1"
-	"k8s.io/api/networking/v1beta1"
+	networkV1 "k8s.io/api/networking/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -132,7 +132,7 @@ func TestJobManagerCreateSuccess(t *testing.T) {
 			labels := map[string]string{
 				"flink-app": "app-name",
 			}
-			ingress := object.(*v1beta1.Ingress)
+			ingress := object.(*networkV1.Ingress)
 			assert.Equal(t, app.Name, ingress.Name)
 			assert.Equal(t, app.Namespace, ingress.Namespace)
 			assert.Equal(t, labels, ingress.Labels)
@@ -215,7 +215,7 @@ func TestJobManagerHACreateSuccess(t *testing.T) {
 			labels := map[string]string{
 				"flink-app": "app-name",
 			}
-			ingress := object.(*v1beta1.Ingress)
+			ingress := object.(*networkV1.Ingress)
 			assert.Equal(t, app.Name, ingress.Name)
 			assert.Equal(t, app.Namespace, ingress.Namespace)
 			assert.Equal(t, labels, ingress.Labels)
@@ -430,7 +430,7 @@ func TestJobManagerCreateSuccessWithVersion(t *testing.T) {
 			labels := map[string]string{
 				"flink-app": "app-name",
 			}
-			ingress := object.(*v1beta1.Ingress)
+			ingress := object.(*networkV1.Ingress)
 			assert.Equal(t, app.Name+"-"+testVersion, ingress.Name)
 			assert.Equal(t, app.Namespace, ingress.Namespace)
 			assert.Equal(t, labels, ingress.Labels)


### PR DESCRIPTION
## overview
networking.k8s.io/v1beta1 API versions of Ingress is no longer served as of v1.22. upgrade to v1

Error: `Failed to create job managers for deploy 0cefa86b: no matches for kind "Ingress" in version "networking.k8s.io/v1beta1"`