### PR TITLE
Change app status to rollback on job start timeout

### DIFF
--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -784,6 +784,7 @@ func (s *FlinkStateMachine) handleSubmittingJob(ctx context.Context, app *v1beta
 	if err != nil {
 		logger.Info(ctx, "Job monitoring failed with error: %v", err)
 		s.flinkController.LogEvent(ctx, app, corev1.EventTypeWarning, "JobMonitoringFailed", err.Error())
+		s.flinkController.UpdateLatestJobID(ctx, app, "")
 		s.updateApplicationPhase(app, v1beta1.FlinkApplicationRollingBackJob)
 		return statusChanged, err
 	}

--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -786,7 +786,6 @@ func (s *FlinkStateMachine) handleSubmittingJob(ctx context.Context, app *v1beta
 		s.flinkController.LogEvent(ctx, app, corev1.EventTypeWarning, "JobMonitoringFailed", err.Error())
 		s.updateApplicationPhase(app, v1beta1.FlinkApplicationRollingBackJob)
 		return statusChanged, err
-		//return statusUnchanged, err
 	}
 	if jobStarted {
 		return updateJobAndReturn(ctx, s, app, hash)

--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -784,7 +784,8 @@ func (s *FlinkStateMachine) handleSubmittingJob(ctx context.Context, app *v1beta
 	if err != nil {
 		logger.Info(ctx, "Job monitoring failed with error: %v", err)
 		s.flinkController.LogEvent(ctx, app, corev1.EventTypeWarning, "JobMonitoringFailed", err.Error())
-		return statusUnchanged, err
+		s.updateApplicationPhase(app, v1beta1.FlinkApplicationRollingBackJob)
+		return statusChanged, err
 	}
 	if jobStarted {
 		return updateJobAndReturn(ctx, s, app, hash)

--- a/pkg/controller/flinkapplication/flink_state_machine.go
+++ b/pkg/controller/flinkapplication/flink_state_machine.go
@@ -786,6 +786,7 @@ func (s *FlinkStateMachine) handleSubmittingJob(ctx context.Context, app *v1beta
 		s.flinkController.LogEvent(ctx, app, corev1.EventTypeWarning, "JobMonitoringFailed", err.Error())
 		s.updateApplicationPhase(app, v1beta1.FlinkApplicationRollingBackJob)
 		return statusChanged, err
+		//return statusUnchanged, err
 	}
 	if jobStarted {
 		return updateJobAndReturn(ctx, s, app, hash)

--- a/pkg/controller/flinkapplication/flink_state_machine_test.go
+++ b/pkg/controller/flinkapplication/flink_state_machine_test.go
@@ -762,7 +762,8 @@ func TestSubmittingVertexFailsToStart(t *testing.T) {
 			assert.Equal(t, jobID, mockFlinkController.GetLatestJobID(ctx, application))
 		} else if statusUpdateCount == 2 {
 			application := object.(*v1beta1.FlinkApplication)
-			assert.Equal(t, "", mockFlinkController.GetLatestJobID(ctx, application))
+			assert.Equal(t, jobID, mockFlinkController.GetLatestJobID(ctx, application))
+			assert.Equal(t, v1beta1.FlinkApplicationDeployFailed, application.Status.Phase)
 		} else if statusUpdateCount == 3 {
 			application := object.(*v1beta1.FlinkApplication)
 			assert.Equal(t, v1beta1.FlinkApplicationRollingBackJob, application.Status.Phase)
@@ -928,9 +929,11 @@ func TestSubmittingVertexStartTimeout(t *testing.T) {
 			assert.Equal(t, jobID, mockFlinkController.GetLatestJobID(ctx, application))
 		} else if statusUpdateCount == 2 {
 			application := object.(*v1beta1.FlinkApplication)
-			assert.Equal(t, "", mockFlinkController.GetLatestJobID(ctx, application))
+			assert.Equal(t, jobID, mockFlinkController.GetLatestJobID(ctx, application))
+			assert.Equal(t, v1beta1.FlinkApplicationDeployFailed, application.Status.Phase)
 		} else if statusUpdateCount == 3 {
 			application := object.(*v1beta1.FlinkApplication)
+			assert.Equal(t, "", mockFlinkController.GetLatestJobID(ctx, application))
 			assert.Equal(t, v1beta1.FlinkApplicationRollingBackJob, application.Status.Phase)
 		}
 		statusUpdateCount++

--- a/pkg/controller/flinkapplication/flink_state_machine_test.go
+++ b/pkg/controller/flinkapplication/flink_state_machine_test.go
@@ -759,11 +759,11 @@ func TestSubmittingVertexFailsToStart(t *testing.T) {
 	mockK8Cluster.UpdateStatusFunc = func(ctx context.Context, object k8sclient.Object) error {
 		if statusUpdateCount == 1 {
 			application := object.(*v1beta1.FlinkApplication)
-			assert.Equal(t, jobID, mockFlinkController.GetLatestJobID(ctx, application))
+			assert.Equal(t, "", mockFlinkController.GetLatestJobID(ctx, application))
 			assert.Equal(t, v1beta1.FlinkApplicationRollingBackJob, application.Status.Phase)
 		} else if statusUpdateCount == 2 {
 			application := object.(*v1beta1.FlinkApplication)
-			assert.Equal(t, jobID, mockFlinkController.GetLatestJobID(ctx, application))
+			assert.Equal(t, "", mockFlinkController.GetLatestJobID(ctx, application))
 			assert.Equal(t, v1beta1.FlinkApplicationDeployFailed, application.Status.Phase)
 		} else if statusUpdateCount == 3 {
 			application := object.(*v1beta1.FlinkApplication)
@@ -928,11 +928,11 @@ func TestSubmittingVertexStartTimeout(t *testing.T) {
 	mockK8Cluster.UpdateStatusFunc = func(ctx context.Context, object k8sclient.Object) error {
 		if statusUpdateCount == 1 {
 			application := object.(*v1beta1.FlinkApplication)
-			assert.Equal(t, jobID, mockFlinkController.GetLatestJobID(ctx, application))
+			assert.Equal(t, "", mockFlinkController.GetLatestJobID(ctx, application))
 			assert.Equal(t, v1beta1.FlinkApplicationRollingBackJob, application.Status.Phase)
 		} else if statusUpdateCount == 2 {
 			application := object.(*v1beta1.FlinkApplication)
-			assert.Equal(t, jobID, mockFlinkController.GetLatestJobID(ctx, application))
+			assert.Equal(t, "", mockFlinkController.GetLatestJobID(ctx, application))
 			assert.Equal(t, v1beta1.FlinkApplicationDeployFailed, application.Status.Phase)
 		} else if statusUpdateCount == 3 {
 			application := object.(*v1beta1.FlinkApplication)

--- a/pkg/controller/flinkapplication/flink_state_machine_test.go
+++ b/pkg/controller/flinkapplication/flink_state_machine_test.go
@@ -760,13 +760,15 @@ func TestSubmittingVertexFailsToStart(t *testing.T) {
 		if statusUpdateCount == 1 {
 			application := object.(*v1beta1.FlinkApplication)
 			assert.Equal(t, jobID, mockFlinkController.GetLatestJobID(ctx, application))
+			assert.Equal(t, v1beta1.FlinkApplicationRollingBackJob, application.Status.Phase)
 		} else if statusUpdateCount == 2 {
 			application := object.(*v1beta1.FlinkApplication)
 			assert.Equal(t, jobID, mockFlinkController.GetLatestJobID(ctx, application))
 			assert.Equal(t, v1beta1.FlinkApplicationDeployFailed, application.Status.Phase)
 		} else if statusUpdateCount == 3 {
 			application := object.(*v1beta1.FlinkApplication)
-			assert.Equal(t, v1beta1.FlinkApplicationRollingBackJob, application.Status.Phase)
+			assert.Equal(t, v1beta1.FlinkApplicationDeployFailed, application.Status.Phase)
+			assert.Equal(t, jobID, mockFlinkController.GetLatestJobID(ctx, application))
 		}
 		statusUpdateCount++
 		return nil
@@ -927,6 +929,7 @@ func TestSubmittingVertexStartTimeout(t *testing.T) {
 		if statusUpdateCount == 1 {
 			application := object.(*v1beta1.FlinkApplication)
 			assert.Equal(t, jobID, mockFlinkController.GetLatestJobID(ctx, application))
+			assert.Equal(t, v1beta1.FlinkApplicationRollingBackJob, application.Status.Phase)
 		} else if statusUpdateCount == 2 {
 			application := object.(*v1beta1.FlinkApplication)
 			assert.Equal(t, jobID, mockFlinkController.GetLatestJobID(ctx, application))
@@ -934,7 +937,7 @@ func TestSubmittingVertexStartTimeout(t *testing.T) {
 		} else if statusUpdateCount == 3 {
 			application := object.(*v1beta1.FlinkApplication)
 			assert.Equal(t, "", mockFlinkController.GetLatestJobID(ctx, application))
-			assert.Equal(t, v1beta1.FlinkApplicationRollingBackJob, application.Status.Phase)
+			assert.Equal(t, v1beta1.FlinkApplicationDeployFailed, application.Status.Phase)
 		}
 		statusUpdateCount++
 		return nil


### PR DESCRIPTION
Once a new Flink job is submitted, it’s possible that the job vertices are not in the running state by the configured timeout period of 3 minutes.

There exists a bug in the flinkk8scontroller where the app will get stuck in this phase, instead of being rolled back and marked as DeployFailed.

Slack [thread](https://lyft.slack.com/archives/CPN3NG47M/p1701461663432759?thread_ts=1701458116.814489&cid=CPN3NG47M)