### PR TITLE
Headless Service

### DIFF
--- a/integ/test.sh
+++ b/integ/test.sh
@@ -6,4 +6,4 @@ export INTEGRATION=true
 export OPERATOR_IMAGE=flinkk8soperator:local
 
 cd $(dirname "$0")
-go test -p 1 -timeout 40m -check.vv IntegSuite
+go test -p 1 -timeout 60m -check.vv IntegSuite

--- a/pkg/controller/flink/job_manager_controller.go
+++ b/pkg/controller/flink/job_manager_controller.go
@@ -221,8 +221,11 @@ func FetchJobManagerServiceCreateObj(app *v1beta1.FlinkApplication, selector str
 			Labels: GetCommonAppLabels(app),
 		},
 		Spec: coreV1.ServiceSpec{
-			Ports:    getJobManagerServicePorts(app),
-			Selector: serviceLabels,
+			Ports:      getJobManagerServicePorts(app),
+			Selector:   serviceLabels,
+			Type:       coreV1.ServiceTypeClusterIP,
+			ClusterIP:  "None",
+			ClusterIPs: []string{},
 		},
 	}
 }


### PR DESCRIPTION
## overview
Change services to headless service as ClusterIP is not required. Apache OSS operator also uses headless services.